### PR TITLE
Add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.bundle
+.git
+log
+tmp
+vendor/bundle
+client


### PR DESCRIPTION
### 概要
dockerイメージ作成時のファイルコピー時に不要なファイルをコピーしないよう`.dockerignore`を作成しました。特に`client`フォルダは不要と思います。
### 技術的変更点
特になし
### 変更に関する影響箇所
`bin/docker setup`実行に作成されるイメージファイル
