### PR TITLE
Modify routes

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,19 +1,20 @@
 class EventsController < ApplicationController
 
-  before_action :set_event, only: [:show, :update, :destroy]
+  before_action :load_community,  only: [:index, :create]
+  before_action :set_event,       only: [:show, :update, :destroy]
 
   def index
-    @events = Event.all
+    @events = @community.events
     render json: @events
   end
 
 
   # paramsハッシュデータをPOSTする場合
   def create
-    @event = Event.new(event_params)
+    @event = @community.events.build(event_params)
     if @event.save
       # resource毎に使うシリアライザーを変えたいときはeach_serializerで指定する
-      render json: @event, status: :created, location: @event
+      render json: @event, status: :created, location: [@community, @event]
     else
       render json: @event.errors, status: :unprocessable_entity
     end
@@ -47,6 +48,10 @@ class EventsController < ApplicationController
 
   def set_event
     @event = Event.find(params[:id])
+  end
+
+  def load_community
+    @community = Community.includes(:events).find(params[:community_id])
   end
 
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ApplicationRecord
+  belongs_to :community
+
   validates :name, presence: true
   validates :description, presence: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-
-  resources :events, :defaults => { :format => 'json' }
-
+  resources :communities, :defaults => { :format => 'json' } do
+      resources :events do
+        resources :tickets
+      end
+      resources :admins
+      resources :owners
+      resources :members
+    end
 end

--- a/spec/factories/communities.rb
+++ b/spec/factories/communities.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+
+  factory :community do
+    name 'Community'
+    description 'Description'
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -2,21 +2,8 @@ require "rails_helper"
 
 describe Event do
   describe 'validation' do
-    subject { event }
-
-    context 'when valid' do
-      let(:event) { Event.create(name: 'test event', description: 'test description') }
-      it { is_expected.to be_valid }
-    end
-
-    context 'when empty name' do
-      let(:event) { Event.create(name: nil, description: 'test description') }
-      it { is_expected.to_not be_valid }
-    end
-
-    context 'when empty description' do
-      let(:event) { Event.create(name: 'test event', description: nil) }
-      it { is_expected.to_not be_valid }
-    end
+    it { is_expected.to belong_to(:community) }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:description) }
   end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1,7 +1,5 @@
 # rails g rspec:integration Event
 
-# TODO: communitiesモデルが追加されたらリクエストパス修正
-
 require 'rails_helper'
 
 RSpec.describe 'Events(イベントAPI)', type: :request do

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -5,13 +5,14 @@
 require 'rails_helper'
 
 RSpec.describe 'Events(イベントAPI)', type: :request do
+  let(:community) { FactoryGirl.create(:community) }
 
-  describe 'GET /events (events#index)' do
+  describe 'GET community_events_path (events#index)' do
 
-    let!(:events) { FactoryGirl.create_list(:event, 2) }
+    let!(:events) { FactoryGirl.create_list(:event, 2, community: community) }
 
     before do
-      get "/events"
+      get community_events_path(community)
     end
 
     context '正常系' do
@@ -36,24 +37,22 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
   end
 
 
-  describe 'POST /events (events#create)' do
-
-    let(:event) { FactoryGirl.create(:event) }
-    let(:event_params) { {event: FactoryGirl.attributes_for(:event)} }
-
-    before do
-      post "/events", params: event_params
-    end
+  describe 'POST community_events_path (events#create)' do
 
     context '正常系' do
 
-      example 'ステータス200を返されること' do
-        expect(response).to be_success
+      let(:event_params) { {event: FactoryGirl.attributes_for(:event)} }
+      before do
+        post community_events_path(community), params: event_params
+      end
+
+      example 'ステータス201を返されること' do
+        expect(response).to have_http_status(:created)
       end
 
       example 'イベントが作成されること' do
         expect do
-          post "/events", params: event_params
+          post community_events_path(community), params: event_params
         end.to change(Event, :count).by(1)
       end
 
@@ -68,8 +67,8 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
 
       example 'JSONからイベント情報が取得できる' do
         result = JSON.parse(response.body)
-        expect(result['name']).to eq(event.name)
-        expect(result['description']).to eq(event.description)
+        expect(result['name']).to eq(event_params[:event][:name])
+        expect(result['description']).to eq(event_params[:event][:description])
       end
 
     end
@@ -77,10 +76,9 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
     context '異常系' do
 
       context 'nameが未記入' do
-        let(:event_name_blank) { FactoryGirl.build(:event_name_blank) }
         let(:event_name_blank_params) { {event: FactoryGirl.attributes_for(:event_name_blank)} }
         before do
-          post '/events', params: event_name_blank_params
+          post community_events_path(community), params: event_name_blank_params
         end
 
         example 'エラーが返ってくること' do
@@ -91,10 +89,9 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
       end
 
       context 'descriptionが未記入' do
-        let(:event_description_blank) { FactoryGirl.build(:event_description_blank) }
         let(:event_description_blank_params) { {event: FactoryGirl.attributes_for(:event_description_blank)} }
         before do
-          post '/events', params: event_description_blank_params
+          post community_events_path(community), params: event_description_blank_params
         end
 
         example 'エラーが返ってくること' do
@@ -105,10 +102,9 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
       end
 
       context 'name, descriptionが未記入' do
-        let(:event_blank) { FactoryGirl.build(:event_blank) }
         let(:event_blank_params) { {event: FactoryGirl.attributes_for(:event_blank)} }
         before do
-          post '/events', params: event_blank_params
+          post community_events_path(community), params: event_blank_params
         end
 
         example 'エラーが返ってくること' do
@@ -122,15 +118,13 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
   end
 
 
-  describe 'GET /events/:id (events#show)' do
-
-    let(:event) { FactoryGirl.create(:event) }
-
-    before do
-      get event_path(event)
-    end
+  describe 'GET community_event_path (events#show)' do
 
     context '正常系' do
+      let(:event) { FactoryGirl.create(:event, community: community) }
+      before do
+        get community_event_path(community, event)
+      end
 
       example 'ステータス200が返ってくること' do
         expect(response).to be_success
@@ -158,7 +152,7 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
     context '異常系' do
 
       before do
-        get '/events/0'
+        get community_event_path(community_id: community.id, id: 0)
       end
 
       context '存在しないイベントを取得する' do
@@ -175,9 +169,9 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
   end
 
 
-  describe 'PATCH /events/:id (events#update)' do
+  describe 'PATCH community_event_path (events#update)' do
 
-    let(:event) { FactoryGirl.create(:event) }
+    let(:event) { FactoryGirl.create(:event, community: community) }
     before do
       @name = event.name
       @description = event.description
@@ -188,7 +182,7 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
       context '有効なパラメータ(name)の場合' do
 
         before do
-          patch "/events/#{event.id}", event: attributes_for(:event, name: 'hogehoge')
+          patch community_event_path(community, event), params: {event: attributes_for(:event, name: 'hogehoge')}
         end
 
         example 'ステータス200が返ってくること' do
@@ -206,7 +200,7 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
       context '有効なパラメータ(description)の場合' do
 
         before do
-          patch "/events/#{event.id}", event: attributes_for(:event, description: 'hogehoge')
+          patch community_event_path(community, event), params: {event: attributes_for(:event, description: 'hogehoge')}
         end
 
         example 'ステータス200が返ってくること' do
@@ -228,7 +222,7 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
       context '無効なパラメータ(name)の場合' do
 
         before do
-          patch "/events/#{event.id}", event: attributes_for(:event, name: nil)
+          patch community_event_path(community, event), params: {event: attributes_for(:event, name: nil)}
         end
 
         example 'ステータス422が返ってくること' do
@@ -245,7 +239,7 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
       context '無効なパラメータ(description)の場合' do
 
         before do
-          patch "/events/#{event.id}", event: attributes_for(:event, description: nil)
+          patch community_event_path(community, event), params: {event: attributes_for(:event, description: nil)}
         end
 
         example 'ステータス422が返ってくること' do
@@ -262,7 +256,7 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
       context '要求されたイベントが存在しない場合' do
 
         before do
-          patch "/events/hogehoge", event: attributes_for(:event, description: 'hogehoge')
+          patch community_event_path(community_id: community.id, id: 0), params: {event: attributes_for(:event, description: 'hogehoge')}
         end
 
         # TODO: eq('text/html')になる。相談の上修正するか決める
@@ -280,16 +274,13 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
   end
 
 
-  describe 'DELETE /events/:id (events#destroy)' do
-
-    # letだと上手くいかない。(itが一つしかなければうまくいく)
-    # let!だと毎回処理される
-    let!(:event) { FactoryGirl.create(:event) }
+  describe 'DELETE community_event_path (events#destroy)' do
 
     context '正常系' do
 
+      let!(:event) { FactoryGirl.create(:event, community: community) }
       subject do
-        delete "/events/#{event.id}", event: event
+        delete community_event_path(community, event)
       end
 
       example 'ステータス200を返すこと' do
@@ -318,7 +309,7 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
       context '要求されたイベントが存在しない場合' do
 
         before do
-          delete '/events/hogehoge'
+          delete community_event_path(community_id: community.id, id: 0)
         end
 
         # TODO: eq('text/html')になる。相談の上修正するか決める


### PR DESCRIPTION
### Overview:概要
https://github.com/shinosakarb/tebukuro/issues/33 に基いて暫定のルーティングを設定。
変更によりEventRequestのテスト等が通らなくなるで修正

### Technical changes:技術的変更点
特になし

### Impact point:変更に関する影響箇所
ルーティングが変更となったため、Eventの全APIのURLが変更。
合わせてテスト実行時に出力されていた下記のワーニングも修正。
`DEPRECATION WARNING: ActionDispatch::IntegrationTest HTTP request methods will accept only`