### PR TITLE
Delete reviewer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,12 @@
 ### Overview:概要
 プルリク（変更）関する概要を記載
+
 ### Technical changes:技術的変更点
 複雑なアルゴリズムの説明
 ライブラリの追加 etc
+
 ### Impact point:変更に関する影響箇所
 変更による他の影響の説明
+
 ### Change of UserInterface:UIの変更
 変更前と変更後のスクリーンショット
-### Reviewer:レビュアー
-見てほしい人


### PR DESCRIPTION
### Overview:概要
GitHub自体にReviewers項目が増えたためPRテンプレートからreviewer項目を削除

### Technical changes:技術的変更点
特になし

### Impact point:変更に関する影響箇所
PRテンプレートからreviewer項目が消える
