### PR TITLE
Add docker file for frontend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,4 @@
 log
 tmp
 vendor/bundle
-client
+front

--- a/bin/docker
+++ b/bin/docker
@@ -13,6 +13,10 @@ case ${1} in
     docker-compose build
   ;;
 
+  front|f)
+    docker-compose exec frontend ${@:2}
+  ;;
+
   *)
     docker-compose exec spring $@
   ;;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,14 @@ services:
     image: busybox
     volumes:
       - "/var/lib/postgresql/data"
+  frontend:
+    build:
+      context: ./front
+      dockerfile: Dockerfile
+    command: "yarn start"
+    volumes:
+      - .:/app
+    ports:
+      - "4000:4000"
+    tty: true
+    stdin_open: true

--- a/front/.dockerignore
+++ b/front/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:7.2.1
+
+RUN apt-get update -qq
+RUN npm install -g yarn
+RUN mkdir /front_app
+WORKDIR /front_app
+ADD package.json /front_app/package.json
+ADD yarn.lock /front_app/yarn.lock
+RUN yarn install
+ADD . /front_app


### PR DESCRIPTION
### Overview:概要
フロント側もDockerでの開発環境を可能にする。

### Technical changes:技術的変更点
特になし

### Impact point:変更に関する影響箇所
`docoker-compose.yml`にフロント分を追記。
それにより`bin/docker setup`や`bin/docker s`等でフロント側のコンテナも立ち上がる
