### PR TITLE
Add reducer of community

### DIFF
--- a/front/client/actions/Community.js
+++ b/front/client/actions/Community.js
@@ -1,0 +1,4 @@
+import { createAction } from 'redux-actions'
+export const ADD_COMMUNITY = 'ADD_COMMUNITY'
+
+export const addCommunity = createAction(ADD_COMMUNITY)

--- a/front/client/models/Community.js
+++ b/front/client/models/Community.js
@@ -1,0 +1,10 @@
+import { Record } from 'immutable'
+
+const CommunityRecord = Record({
+  id:           0,
+  name:         '',
+  description:  ''
+})
+
+export default class Community extends CommunityRecord {
+}

--- a/front/client/reducers/Community.js
+++ b/front/client/reducers/Community.js
@@ -1,0 +1,16 @@
+import { handleActions }  from 'redux-actions'
+import Community          from '../models/Community'
+
+export const communityInitialState = new Community()
+
+export const communityReducerMap = {
+  ADD_COMMUNITY(state, action) {
+    return new Community({
+      id:           action.payload.id,
+      name:         action.payload.name,
+      description:  action.payload.description
+    })
+  }
+}
+
+export default handleActions(communityReducerMap, communityInitialState)

--- a/front/client/reducers/__tests__/Community.spec.js
+++ b/front/client/reducers/__tests__/Community.spec.js
@@ -1,0 +1,25 @@
+import CommunityReducer from '../Community'
+import { addCommunity } from '../../actions/Community'
+import CommunityModel   from '../../models/Community'
+
+const model = (params) => {
+  return new CommunityModel(params)
+}
+
+describe('Community', () => {
+  describe('ADD_COMMUNITY', () => {
+    it("should handle ADD_COMMUNITY", () => {
+      const subject = CommunityReducer(
+        model(),
+        addCommunity({
+          id:           10,
+          name:         'communityName',
+          description:  'communityDescription'
+        })
+      )
+      expect(subject.id).toBe(10)
+      expect(subject.name).toBe('communityName')
+      expect(subject.description).toBe('communityDescription')
+    })
+  })
+})


### PR DESCRIPTION
### Overview:概要
Community登録を行うためのReducer部分を作成

### Technical changes:技術的変更点
- immutable.jsを使用する前提でのreducer作成
- reducer以外にも必要なactionを同時に作成

### Impact point:変更に関する影響箇所
本Reducerを既存の動作には組み込んでいないため影響はし。

とりあえずはReducer部分だけを作ったのでここだけでレビュー
actionとmodelについては現実装では実処理はないのでこの状態ではテストコードは作成しない。
