### PR TITLE
Add waiting process for DB container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
 FROM ruby:2.3.1
 
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs postgresql-client
 RUN mkdir /app
 WORKDIR /app
 ADD Gemfile /app/Gemfile
 ADD Gemfile.lock /app/Gemfile.lock
 RUN bundle install -j4
 ADD . /app
-
-ENV DATABASE_HOST db
-ENV DATABASE_USERNAME postgres
-ENV DATABASE_PASSWORD ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,18 +2,22 @@ version: '2'
 services:
   backend: &app_base
     build: .
-    command: "bundle exec rails s -p 3000 -b '0.0.0.0'"
+    command: "sh /app/wait.sh bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/app
     ports:
       - "3000:3000"
+    environment:
+      - DATABASE_HOST=db
+      - DATABASE_USERNAME=postgres
+      - DATABASE_PASSWORD=""
     depends_on:
       - db
     tty: true
     stdin_open: true
   spring:
     <<: *app_base
-    command: "bundle exec spring server"
+    command: "sh /app/wait.sh bundle exec spring server"
     ports: []
     tty: false
     stdin_open: false

--- a/wait.sh
+++ b/wait.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+host="$DATABASE_HOST"
+user="$DATABASE_USERNAME"
+export PGPASSWD="$DATABASE_PASSWORD"
+cmd="$@"
+
+echo "Waiting for psql"
+until psql -h "$host" -U "$user" &> /dev/null
+do
+  >$2 echo -n "."
+  sleep 1
+done
+
+>&2 echo "PostgreSQL is up - executing command"
+exec $cmd


### PR DESCRIPTION
### Overview:概要
docker-composeでの起動順コントロールを追加

### Impact point:変更に関する影響箇所
`bin/docker s`や`docker-compose up`で起動する際にDBコンテナが立ち上がっていない状態で
RailsコンテナやSpringコンテナが立ち上がるとDB接続エラーとなり、正常に起動できない。
そこでDBコンテナが立ち上がってからRailsコンテナが立ち上がるように制御。
制御の方法はpsqlコマンドにてDB接続が確認でき次第立ち上がるシェルスクリプトを用意し、
起動時にそのスクリプトを実行するように変更。

参考: https://docs.docker.com/compose/startup-order/
