### PR TITLE
Fix generator setting to not create `controller` and `routes` for RSpec

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,11 @@ module Tebukuro
 
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
+    config.generators do |g|
+      g.test_framework :rspec,
+        routing_specs: false,
+        controller_specs: false
+    end
   end
 end


### PR DESCRIPTION
### Overview:概要
現状、tebukuroでは **model** と **request** のテストしかしていないので、
generatorで **controller** と **routes** のRSpecファイルを作成しないようにした。

今後、テストが必要になったときは随時設定を変更すればいい。
