### PR TITLE
Add react-router and react-router-redux

### DIFF
--- a/front/client/components/CommunityList/index.js
+++ b/front/client/components/CommunityList/index.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Link } from 'react-router'
+
+const CommunityList = () => {
+  return (
+    <div>
+      <div>community list sample</div>
+
+      <Link to="/communities/new">new</Link>
+    </div>
+  )
+}
+
+export default CommunityList

--- a/front/client/components/Top/index.js
+++ b/front/client/components/Top/index.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Link } from 'react-router'
+
+const Top = () => {
+  return (
+    <div>
+      <div>tebukuro top sample</div>
+
+      <Link to="/communities">Community List</Link>
+    </div>
+  )
+}
+
+export default Top

--- a/front/client/containers/App/index.js
+++ b/front/client/containers/App/index.js
@@ -1,13 +1,10 @@
 import React, { Component } from 'react'
-import CommunityForm from '../../components/CommunityForm/index'
 
 export default class App extends Component {
   render() {
     return (
       <div>
-        tebukuro example
-
-        <CommunityForm />
+        {this.props.children}
       </div>
     )
   }

--- a/front/client/containers/Root/index.js
+++ b/front/client/containers/Root/index.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Provider } from 'react-redux'
+import { Router, Route, IndexRoute } from 'react-router'
+import App from '../App'
+import Top from '../../components/Top'
+import CommunityList from '../../components/CommunityList'
+import CommunityForm from '../../components/CommunityForm'
+
+export default class Root extends React.Component {
+  static propTypes = {
+    history: React.PropTypes.object.isRequired,
+    store: React.PropTypes.object.isRequired
+  }
+
+  render() {
+    const { store, history } = this.props
+    return (
+      <Provider store={store}>
+        <Router history={history}>
+          <Route path="/" component={App}>
+            <IndexRoute component={Top}/>
+            <Route path="communities" component={CommunityList}/>
+            <Route path="communities/new" component={CommunityForm}/>
+          </Route>
+        </Router>
+      </Provider>
+    )
+  }
+}

--- a/front/client/index.js
+++ b/front/client/index.js
@@ -1,29 +1,28 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { AppContainer } from 'react-hot-loader'
-import store from './store'
-import App from './containers/App'
-import { Provider } from 'react-redux'
+import configureStore from './store'
+import { browserHistory } from 'react-router'
+import { syncHistoryWithStore } from 'react-router-redux'
+import Root from './containers/Root'
 
-ReactDOM.render(
-  <Provider store={store}>
+const state = {}
+const store = configureStore(state, browserHistory)
+const history = syncHistoryWithStore(browserHistory, store)
+
+const renderApp = (RootComponent) => {
+  ReactDOM.render(
     <AppContainer>
-      <App/>
-    </AppContainer>
-  </Provider>,
-  document.getElementById('root')
-)
+      <RootComponent store={store} history={history} />
+    </AppContainer>,
+    document.getElementById('root')
+  )
+}
+
+renderApp(Root)
 
 if (module.hot) {
-  module.hot.accept('./containers/App', () => {
-    const NextApp = require('./containers/App').default
-    ReactDOM.render(
-      <Provider store={store}>
-        <AppContainer>
-          <NextApp/>
-        </AppContainer>
-      </Provider>,
-      document.getElementById('root')
-    )
+  module.hot.accept('./containers/Root', () => {
+    renderApp(require('./containers/Root').default)
   })
 }

--- a/front/client/reducers/index.js
+++ b/front/client/reducers/index.js
@@ -1,6 +1,8 @@
 import { combineReducers } from 'redux'
+import { routerReducer } from 'react-router-redux'
 import Community from './Community'
 
 export default combineReducers({
-  Community
+  Community,
+  routing: routerReducer
 })

--- a/front/client/store/index.js
+++ b/front/client/store/index.js
@@ -1,6 +1,7 @@
-import { createStore } from 'redux'
+import { createStore, applyMiddleware } from 'redux'
+import { routerMiddleware } from 'react-router-redux'
 import TebukuroApp from '../reducers'
 
-const store = createStore(TebukuroApp)
-
-export default store
+export default (preloadState = {}, history) => {
+  return createStore(TebukuroApp, {}, applyMiddleware(routerMiddleware(history)))
+}

--- a/front/client/store/index.js
+++ b/front/client/store/index.js
@@ -3,5 +3,9 @@ import { routerMiddleware } from 'react-router-redux'
 import TebukuroApp from '../reducers'
 
 export default (preloadState = {}, history) => {
-  return createStore(TebukuroApp, {}, applyMiddleware(routerMiddleware(history)))
+  const middlewares = [
+    routerMiddleware(history)
+  ]
+
+  return createStore(TebukuroApp, {}, applyMiddleware(...middlewares))
 }

--- a/front/package.json
+++ b/front/package.json
@@ -19,6 +19,8 @@
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-redux": "^5.0.1",
+    "react-router": "^3.0.0",
+    "react-router-redux": "^4.0.7",
     "redux": "^3.6.0",
     "redux-actions": "^1.2.0",
     "redux-promise": "^0.5.3",

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -2346,11 +2346,20 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
+history@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-3.2.1.tgz#71c7497f4e6090363d19a6713bb52a1bfcdd99aa"
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    query-string "^4.2.2"
+    warning "^3.0.0"
+
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^1.0.3:
+hoist-non-react-statics@^1.0.3, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
@@ -3351,7 +3360,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.0.tgz#6b26248c42f6d4fa4b0d8542f78edfcde35642a8"
   dependencies:
@@ -4404,7 +4413,7 @@ qs@^6.1.0, qs@~6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"
 
-query-string@^4.1.0:
+query-string@^4.1.0, query-string@^4.2.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.2.3.tgz#9f27273d207a25a8ee4c7b8c74dcd45d556db822"
   dependencies:
@@ -4485,6 +4494,20 @@ react-redux@^5.0.1:
     lodash "^4.2.0"
     lodash-es "^4.2.0"
     loose-envify "^1.1.0"
+
+react-router-redux@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.7.tgz#9b1fde4e70106c50f47214e12bdd888cfb96e2a6"
+
+react-router@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.0.0.tgz#3f313e4dbaf57048c48dd0a8c3cac24d93667dff"
+  dependencies:
+    history "^3.0.0"
+    hoist-non-react-statics "^1.2.0"
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    warning "^3.0.0"
 
 react-test-renderer@^15.4.1:
   version "15.4.1"
@@ -5221,6 +5244,12 @@ walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watch@~0.10.0:
   version "0.10.0"


### PR DESCRIPTION
### Overview:概要
https://github.com/shinosakarb/tebukuro/issues/77 フロント側での画面遷移処理の追加

### Technical changes:技術的変更点
react-routerおよびreact-router-reduxを導入し作成予定である下記の画面遷移を実装
* 「ページトップ」→「コミュニティ一覧」→「コミュニティ登録」

本実装はreact-routerのver3.0.0で実装されているが、v4.0.0では大幅に変わるため再度修正が必要となる。
現状でv4.0.0を採用しなかった理由はreact-router-redux側がreact-routerのver4.0.0に対応していないためである。
参考：https://github.com/reactjs/react-router-redux/pull/460

### Impact point:変更に関する影響箇所
後に追加するであろう下記画面を先行し、形のみ登録
* トップページ
* コミュニティ一覧
