### PR TITLE
Add performance option to webpack config

### DIFF
--- a/front/config/webpack/webpack.dev.config.js
+++ b/front/config/webpack/webpack.dev.config.js
@@ -52,5 +52,8 @@ module.exports = {
         loader: 'file-loader?name=[name].[ext]'
       }
     ]
+  },
+  performance: {
+    hints: false
   }
 }


### PR DESCRIPTION
### Overview:概要
webpack2.xから[Performance オプション](https://webpack.js.org/configuration/performance/)が追加されていて、defaultではwarning になっている.

開発環境では必要ないのでOFFにする.

### Technical changes:技術的変更点
特になし

### Impact point:変更に関する影響箇所
webpack.dev.config.jsにperformanceのオプションを追加.

### 確認方法
* [x] yarn startしてwebpackのログにワーニングが表示されていない
* [x] http://localhost:4000/ にアクセスしてwelcomeページが表示できる
