### PR TITLE
Add reducer of CommunityList

### DIFF
--- a/front/__tests__/reducers/Community.spec.js
+++ b/front/__tests__/reducers/Community.spec.js
@@ -1,17 +1,17 @@
-import CommunityReducer from '../../client/reducers/Community'
-import { addCommunity } from '../../client/actions/Community'
-import CommunityModel   from '../../client/models/Community'
+import CommunityReducer     from '../../client/reducers/Community'
+import { createCommunity }  from '../../client/actions/Community'
+import CommunityModel       from '../../client/models/Community'
 
 const model = (params) => {
   return new CommunityModel(params)
 }
 
 describe('Community', () => {
-  describe('ADD_COMMUNITY', () => {
-    it("should handle ADD_COMMUNITY", () => {
+  describe('CREATE_COMMUNITY', () => {
+    it("should handle CREATE_COMMUNITY", () => {
       const subject = CommunityReducer(
         model(),
-        addCommunity({
+        createCommunity({
           id:           10,
           name:         'communityName',
           description:  'communityDescription'

--- a/front/__tests__/reducers/CommunityList.spec.js
+++ b/front/__tests__/reducers/CommunityList.spec.js
@@ -1,0 +1,39 @@
+import CommunityListReducer from '../../client/reducers/CommunityList'
+import { createCommunities }   from '../../client/actions/CommunityList'
+import CommunityListModel   from '../../client/models/CommunityList'
+
+const model = (params) => {
+  return new CommunityListModel(params)
+}
+
+describe('CommunityList', () => {
+  describe('CREATE_COMMUNITIES', () => {
+    it("should handle CREATE_COMMUNITIES", () => {
+      const values = [
+        {
+          id:           11,
+          name:         'communityName1',
+          description:  'communityDescription1'
+        },
+        {
+          id:           12,
+          name:         'communityName2',
+          description:  'communityDescription2'
+        }
+      ]
+      const subject = CommunityListReducer(
+        model(),
+        createCommunities(values)
+      )
+
+      expect(subject.communities.count()).toBe(2)
+      let index = 0
+      subject.communities.forEach((community) => {
+        expect(community.id).toBe(values[index].id)
+        expect(community.name).toBe(values[index].name)
+        expect(community.description).toBe(values[index].description)
+        index += 1
+      })
+    })
+  })
+})

--- a/front/client/actions/Community.js
+++ b/front/client/actions/Community.js
@@ -1,4 +1,4 @@
 import { createAction } from 'redux-actions'
-export const ADD_COMMUNITY = 'ADD_COMMUNITY'
+export const CREATE_COMMUNITY = 'CREATE_COMMUNITY'
 
-export const addCommunity = createAction(ADD_COMMUNITY)
+export const createCommunity = createAction(CREATE_COMMUNITY)

--- a/front/client/actions/CommunityList.js
+++ b/front/client/actions/CommunityList.js
@@ -1,0 +1,4 @@
+import { createAction } from 'redux-actions'
+export const CREATE_COMMUNITIES = 'CREATE_COMMUNITIES'
+
+export const createCommunities = createAction(CREATE_COMMUNITIES)

--- a/front/client/models/CommunityList.js
+++ b/front/client/models/CommunityList.js
@@ -1,7 +1,7 @@
 import { Record, Set } from 'immutable'
 
 const CommunityListRecord = Record({
-  communities: Set.new()
+  communities: Set.of()
 })
 
 export default class CommunityList extends CommunityListRecord {

--- a/front/client/models/CommunityList.js
+++ b/front/client/models/CommunityList.js
@@ -1,0 +1,11 @@
+import { Record, Set } from 'immutable'
+
+const CommunityListRecord = Record({
+  communities: Set.new()
+})
+
+export default class CommunityList extends CommunityListRecord {
+  setCommunities(list) {
+    return this.set('communities', Set.of(...list))
+  }
+}

--- a/front/client/reducers/Community.js
+++ b/front/client/reducers/Community.js
@@ -4,7 +4,7 @@ import Community          from '../models/Community'
 export const communityInitialState = new Community()
 
 export const communityReducerMap = {
-  ADD_COMMUNITY(state, action) {
+  CREATE_COMMUNITY(state, action) {
     return new Community({
       id:           action.payload.id,
       name:         action.payload.name,

--- a/front/client/reducers/CommunityList.js
+++ b/front/client/reducers/CommunityList.js
@@ -1,0 +1,21 @@
+import { handleActions }        from 'redux-actions'
+import CommunityList            from '../models/CommunityList'
+import { communityReducerMap }  from './Community'
+
+export const communityListInitialState = new CommunityList()
+
+export const communityListReducerMap = {
+  CREATE_COMMUNITIES(state, action) {
+    const communityList = new CommunityList()
+    return communityList.setCommunities(
+      action.payload.map((item) => {
+        return communityReducerMap.CREATE_COMMUNITY(
+          null,
+          {payload: {id: item.id, name: item.name, description: item.description}}
+        )
+      })
+    )
+  }
+}
+
+export default handleActions(communityListReducerMap, communityListInitialState)


### PR DESCRIPTION
### Overview:概要
https://github.com/shinosakarb/tebukuro/issues/76 コミュニティ一覧画面で使用するreducerを作成

### Technical changes:技術的変更点
特になし

### Impact point:変更に関する影響箇所
コミュニティreducerのアクション名がイマイチかつ、コミュニティ一覧でも使用するためアクション名を変更。
そのため、コミュニティ登録画面が現在進行中と思われるが、本PRもしくはそちらのPRのどちらかが先にマージされた場合は、後のPRを修正する必要がある。
コミュニティ一覧reducerに関しては新規作成かつ使用箇所はないため、既存機能には影響はなし。