### PR TITLE
Modify name of api to createCommunity

### DIFF
--- a/front/__tests__/api/Community.spec.js
+++ b/front/__tests__/api/Community.spec.js
@@ -1,56 +1,58 @@
 import nock from 'nock'
 import * as CommunityAPI from '../../client/api/Community'
 
-describe('createCommunityHandler', () => {
-  describe('when valid param', () => {
-    const name = 'communityName'
-    const description = 'communityDescription'
-
-    it('should return action', () => {
-      const id = 1
+describe('Community', () => {
+  describe('createCommunity', () => {
+    describe('when valid param', () => {
       const name = 'communityName'
       const description = 'communityDescription'
 
-      const response = {
-        id: id,
-        name: name,
-        description: description
-      }
+      it('should return action', () => {
+        const id = 1
+        const name = 'communityName'
+        const description = 'communityDescription'
 
-      nock(Config.ApiEndPoint)
-      .post('/communities')
-      .reply(201, response)
+        const response = {
+          id: id,
+          name: name,
+          description: description
+        }
 
-      return CommunityAPI.createCommunityHandler(name, description)
-      .then((payload) => {
-        expect(payload.id).toBe(response.id)
-        expect(payload.name).toBe(response.name)
-        expect(payload.description).toBe(response.description)
+        nock(Config.ApiEndPoint)
+        .post('/communities')
+        .reply(201, response)
+
+        return CommunityAPI.createCommunity(name, description)
+        .then((payload) => {
+          expect(payload.id).toBe(response.id)
+          expect(payload.name).toBe(response.name)
+          expect(payload.description).toBe(response.description)
+        })
       })
     })
-  })
 
-  describe('when invalid param', () => {
-    it('should return action with error', () => {
-      const nameError = ['を入力してください']
-      const descriptionError = ['を入力してください']
+    describe('when invalid param', () => {
+      it('should return action with error', () => {
+        const nameError = ['を入力してください']
+        const descriptionError = ['を入力してください']
 
-      const response = {
-        name: nameError,
-        description: descriptionError
-      }
+        const response = {
+          name: nameError,
+          description: descriptionError
+        }
 
-      nock(Config.ApiEndPoint)
-      .post('/communities')
-      .reply(422, response)
+        nock(Config.ApiEndPoint)
+        .post('/communities')
+        .reply(422, response)
 
-      const name = ''
-      const description = ''
+        const name = ''
+        const description = ''
 
-      return CommunityAPI.createCommunityHandler(name, description)
-      .catch((payload) => {
-        expect(payload.messages[0]).toContain('name')
-        expect(payload.messages[1]).toContain('description')
+        return CommunityAPI.createCommunity(name, description)
+        .catch((payload) => {
+          expect(payload.messages[0]).toContain('name')
+          expect(payload.messages[1]).toContain('description')
+        })
       })
     })
   })

--- a/front/client/actions/Community.js
+++ b/front/client/actions/Community.js
@@ -1,6 +1,6 @@
 import { createAction } from 'redux-actions'
-import { createCommunityHandler } from '../api/Community'
+import { createCommunity as createAPI } from '../api/Community'
 
 export const CREATE_COMMUNITY = 'CREATE_COMMUNITY'
 
-export const createCommunity = createAction(CREATE_COMMUNITY, createCommunityHandler)
+export const createCommunity = createAction(CREATE_COMMUNITY, createAPI)

--- a/front/client/api/Community.js
+++ b/front/client/api/Community.js
@@ -1,7 +1,7 @@
 import ApiRequest from './ApiRequest'
 import request from 'superagent'
 
-export const createCommunityHandler = (name, description) => {
+export const createCommunity = (name, description) => {
   const communityParams = {
     name: name,
     description: description


### PR DESCRIPTION
### Overview:概要
Changed api name to createCommunity from createCommunityHandler.

### Technical changes:技術的変更点
nothing.

### Impact point:変更に関する影響箇所
* Changed caller name of API function.
* Fix hierarchy of test code.

Confirmation method
- [x] Running `yarn test`.
- [x] Open community registration page and community can register.
