### PR TITLE
Change ruby version to 2.4.0

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: ruby:2.3.1
+box: ruby:2.4.0
 
 services:
   - id: postgres


### PR DESCRIPTION
### Overview:概要
werckerのRubyバージョンを2.4.0に修正

### Technical changes:技術的変更点
なし

### Impact point:変更に関する影響箇所
なし
