### PR TITLE
Update docker compose to v3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN mkdir /app
 WORKDIR /app
 ADD Gemfile /app/Gemfile
 ADD Gemfile.lock /app/Gemfile.lock
-RUN bundle install -j4
+RUN bundle install --path vendor/bundle -j4
 ADD . /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
-version: '2'
+version: '3'
 services:
   backend: &app_base
     build: .
     command: "sh /app/wait.sh bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/app
+      - /app/vendor
     ports:
       - "3000:3000"
     environment:
@@ -23,12 +24,8 @@ services:
     stdin_open: false
   db:
     image: postgres:9.6-alpine
-    volumes_from:
-      - data
-  data:
-    image: busybox
     volumes:
-      - "/var/lib/postgresql/data"
+      - postgresql-webapp-data:/var/lib/postgresql
   frontend:
     build:
       context: ./front
@@ -41,3 +38,5 @@ services:
       - "4000:4000"
     tty: true
     stdin_open: true
+volumes:
+  postgresql-webapp-data:


### PR DESCRIPTION
### Overview:概要
Update docker compose to version 3

### Technical changes:技術的変更点
* `volumes_from` is removed. So change to `volumes` option.
* Fix gems mounted volume so that it does not depend on host.  
This eliminates the need to recreate image when adding gem.

### Impact point:変更に関する影響箇所
Docker Engine:1.13.0+

Confirmation method
* [ ] `bin/docker setup` can be executed.
* [ ] `bin/docker s` can be executed.
* [ ] `http://localhost:4000` can open a top page.