### PR TITLE
Set omniauth

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,9 @@ module Tebukuro
         routing_specs: false,
         controller_specs: false
     end
+
+    config.middleware.use config.session_store, config.session_options
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -239,7 +239,7 @@ Devise.setup do |config|
   # should add them to the navigational formats lists.
   #
   # The "*/*" below is required to match Internet Explorer requests.
-  # config.navigational_formats = ['*/*', :html]
+  config.navigational_formats = [:json]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,12 @@
+OmniAuth.config.logger = Rails.logger
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :twitter,
+    Rails.application.secrets.twitter_key,  Rails.application.secrets.twitter_secret
+  provider :github,
+    Rails.application.secrets.github_key,  Rails.application.secrets.github_secret,
+    scope: "user:email"
+  provider :facebook,
+    Rails.application.secrets.facebook_key,  Rails.application.secrets.facebook_secret,
+    scope: "email"
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,11 +12,29 @@
 
 development:
   secret_key_base: 7cac37cbc31dc99c5b52b749ff1fa7b4323e8f584176552c0510068a593f11ec6ab45f98cb56464f36a07a73bfa9f4f5838399960f9e996f82a1b2c15f4973db
+  twitter_key: 591c141f69d498f35e7e0ea6efe0f06971f189988ae4a17d73ebefe1cb59c579ac94632fd008a19aa49d9330b3ce4c0506ad89789b6bb933af76d26fe44bd863 #dummy
+  twitter_secret: e2bd2feaede8f1d03d524e2036e2f4cec0f7a3b77a7ff51c2f06e0221da67d4d79a5366a473d71280592e4e8c7cbdc9fef2061cc5409ab4e464d74eab558b8bd #dummy
+  github_key: 8f17197c8193871ca1db
+  github_secret: 69958e21e76d07a89fb855d18fe2b6539df6a0d5
+  facebook_key: 1fc9d4633d3d903cd5c99d443b4e02330605c2ccd3357ca73730f8e4ca7eac31811328da6c8fa19d35e6af4f629c7550aa83ec7436c8f985922c1942bafb9b2c #dummy
+  facebook_secret: 4fdd54c191e5fa1ceef7554fe55f4037cff2ca884824a8e15fc7c6be421fa630207a35c09776bc9bdf580b37b9cc744a1dd2923ec87284e55849abcee5192dfb #dummy
 
 test:
   secret_key_base: 478092cd7e6d88e06df69a173c42119ba70a89294086cbbdc8ab9ae3ae17e1dc8db3f658fb86253d3084ccb8cc739e4d4e80fb9c0f4f96e0a8604dd505447c7c
+  twitter_key: testtwitterkey
+  twitter_secret: testtwittersecret
+  github_key: testgithubkey
+  github_secret: testgithubsecret
+  facebook_key: testfacebookkey
+  facebook_secret: testfacebooksecret
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  twitter_key: <%= ENV["TWITTER_KEY"] %>
+  twitter_secret: <%= ENV["TWITTER_SECRET"] %>
+  github_key: <%= ENV["GITHUB_KEY"] %>
+  github_secret: <%= ENV["GITHUB_SECRET"] %>
+  facebook_key: <%= ENV["FACEBOOK_KEY"] %>
+  facebook_secret: <%= ENV["FACEBOOK_SECRET"] %>


### PR DESCRIPTION
### Overview:概要
Set omniauth of `devise_token_auth`

### Technical changes:技術的変更点
Add middleware to be used by `devise_token_auth`.

### Impact point:変更に関する影響箇所
nothing.

Confirmation method
* [x] `rails s` or `bin/docker s` can be executed.
* [x] When `http://localhost:3000/auth/github` is opened, it is redirected to `http://localhost:3000/auth/github/callback`.
* [x] Data is created in the User table

### Consultation
**Firstly set only GitHub's KEY. Twitter and facebook are dummy and will not work.**