### PR TITLE
Refactoring to consolidate request URLs in one place

### DIFF
--- a/front/__tests__/api/ApiRequest.js
+++ b/front/__tests__/api/ApiRequest.js
@@ -1,5 +1,6 @@
 import nock from 'nock'
 import ApiRequest from '../../client/api/ApiRequest'
+import RequestUrls from '../../client/constants/RequestUrls'
 
 describe('ApiRequest', () => {
   describe('post', () => {
@@ -16,20 +17,20 @@ describe('ApiRequest', () => {
         }
 
         nock(Config.ApiEndPoint)
-        .post('/communities')
-        .reply(201, response)
+          .post(RequestUrls.communities)
+          .reply(201, response)
 
         const communityParams = {
           name: name,
           description: description
         }
 
-        return ApiRequest.post('/communities', communityParams)
-        .then((payload) => {
-          expect(payload.id).toBe(response.id)
-          expect(payload.name).toBe(response.name)
-          expect(payload.description).toBe(response.description)
-        })
+        return ApiRequest.post(RequestUrls.communities, communityParams)
+          .then((payload) => {
+            expect(payload.id).toBe(response.id)
+            expect(payload.name).toBe(response.name)
+            expect(payload.description).toBe(response.description)
+          })
       })
     })
 
@@ -44,19 +45,19 @@ describe('ApiRequest', () => {
         }
 
         nock(Config.ApiEndPoint)
-        .post('/communities')
-        .reply(422, response)
+          .post(RequestUrls.communities)
+          .reply(422, response)
 
         const communityParams = {
           name: '',
           description: ''
         }
 
-        return ApiRequest.post('/communities', communityParams)
-        .catch((payload) => {
-          expect(payload.messages[0]).toContain('name')
-          expect(payload.messages[1]).toContain('description')
-        })
+        return ApiRequest.post(RequestUrls.communities, communityParams)
+          .catch((payload) => {
+            expect(payload.messages[0]).toContain('name')
+            expect(payload.messages[1]).toContain('description')
+          })
       })
     })
   })

--- a/front/__tests__/api/Community.spec.js
+++ b/front/__tests__/api/Community.spec.js
@@ -1,5 +1,6 @@
 import nock from 'nock'
 import * as CommunityAPI from '../../client/api/Community'
+import RequestUrls from '../../client/constants/RequestUrls'
 
 describe('Community', () => {
   describe('createCommunity', () => {
@@ -19,15 +20,15 @@ describe('Community', () => {
         }
 
         nock(Config.ApiEndPoint)
-        .post('/communities')
-        .reply(201, response)
+          .post(RequestUrls.communities)
+          .reply(201, response)
 
         return CommunityAPI.createCommunity(name, description)
-        .then((payload) => {
-          expect(payload.id).toBe(response.id)
-          expect(payload.name).toBe(response.name)
-          expect(payload.description).toBe(response.description)
-        })
+          .then((payload) => {
+            expect(payload.id).toBe(response.id)
+            expect(payload.name).toBe(response.name)
+            expect(payload.description).toBe(response.description)
+          })
       })
     })
 
@@ -42,17 +43,17 @@ describe('Community', () => {
         }
 
         nock(Config.ApiEndPoint)
-        .post('/communities')
-        .reply(422, response)
+          .post(RequestUrls.communities)
+          .reply(422, response)
 
         const name = ''
         const description = ''
 
         return CommunityAPI.createCommunity(name, description)
-        .catch((payload) => {
-          expect(payload.messages[0]).toContain('name')
-          expect(payload.messages[1]).toContain('description')
-        })
+          .catch((payload) => {
+            expect(payload.messages[0]).toContain('name')
+            expect(payload.messages[1]).toContain('description')
+          })
       })
     })
   })
@@ -62,7 +63,7 @@ describe('Community', () => {
       const response = [{id: 1, name: "name1", description: "description1"}, {id: 2, name: "name2", description: "description2"}]
 
       nock(Config.ApiEndPoint)
-        .get('/communities.json')
+        .get(RequestUrls.communities)
         .reply(200, response)
       const subject = await CommunityAPI.getCommunities()
       expect(subject).toEqual(response)

--- a/front/client/api/Community.js
+++ b/front/client/api/Community.js
@@ -1,15 +1,16 @@
 import ApiRequest from './ApiRequest'
 import request from 'superagent'
+import RequestUrls from '../constants/RequestUrls'
 
 export const createCommunity = (name, description) => {
   const communityParams = {
     name: name,
     description: description
   }
-  return ApiRequest.post('/communities', communityParams)
+  return ApiRequest.post(RequestUrls.communities, communityParams)
 }
 
 export const getCommunities = () => {
-  return request.get(`${Config.ApiEndPoint}/communities.json`)
+  return request.get(`${Config.ApiEndPoint}${RequestUrls.communities}`)
     .then(res => res.body)
 }

--- a/front/client/constants/RequestUrls.js
+++ b/front/client/constants/RequestUrls.js
@@ -1,0 +1,3 @@
+export default {
+  "communities": "/communities"
+}

--- a/front/client/containers/CommunityForm/index.js
+++ b/front/client/containers/CommunityForm/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { createCommunity } from '../actions/Community'
-import CommunityForm from '../components/CommunityForm'
+import { createCommunity } from '../../actions/Community'
+import CommunityForm from '../../components/CommunityForm'
 
 const mapStateToProps = (state, ownProps) => {
   return {

--- a/front/client/containers/Root/index.js
+++ b/front/client/containers/Root/index.js
@@ -4,7 +4,7 @@ import { Router, Route, IndexRoute } from 'react-router'
 import App from '../App'
 import Top from '../../components/Top'
 import CommunityList from '../CommunityList'
-import CreateCommunityForm from '../CreateCommunityForm'
+import CreateCommunityForm from '../CommunityForm'
 
 export default class Root extends React.Component {
   static propTypes = {


### PR DESCRIPTION
## **Why is this refactoring necessary?**
If it remains as it is, the request URLs may be scattered. The purpose is to consolidate the request URLs in one place.

### Overview:概要
Refactoring community features

### Technical changes:技術的変更点
nothing.

### Impact point:変更に関する影響箇所
* Move `CreateCommunityForm.js` to `containers` directory
* Define the request URL to the backend in the `constants` directory
