### PR TITLE
Add OAuth signin button

### DIFF
--- a/front/__tests__/components/Avatar.spec.js
+++ b/front/__tests__/components/Avatar.spec.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import AvatarComponent from '../../client/components/Avatar'
+import {shallow} from 'enzyme'
+import toJson from 'enzyme-to-json'
+
+describe('Avatar', () => {
+  const subject = (src) => (shallow(<AvatarComponent src={src} />))
+
+  test('render Avatar', () => {
+    const src = 'example.png'
+    expect(toJson(subject(src))).toMatchSnapshot()
+  })
+
+  test('not render Avatar', () => {
+    const src = undefined
+    expect(toJson(subject(src))).toMatchSnapshot()
+  })
+})

--- a/front/__tests__/components/OAuth.spec.js
+++ b/front/__tests__/components/OAuth.spec.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import {Map} from 'immutable'
+import OAuthComponent from '../../client/components/OAuth'
+import {shallow} from 'enzyme'
+import toJson from 'enzyme-to-json'
+
+describe('OAuth', () => {
+  const subject = (auth) => (shallow(<OAuthComponent auth={auth} />))
+
+  test('render Signin', () => {
+    const auth = Map({user: Map({isSignedIn: true, attributes: Map({image: 'example.png'})})})
+    expect(toJson(subject(auth))).toMatchSnapshot()
+  })
+
+  test('render Signout', () => {
+    const auth = Map({user: Map({isSignedIn: false})})
+    expect(toJson(subject(auth))).toMatchSnapshot()
+  })
+})

--- a/front/__tests__/components/__snapshots__/Avatar.spec.js.snap
+++ b/front/__tests__/components/__snapshots__/Avatar.spec.js.snap
@@ -1,0 +1,10 @@
+exports[`Avatar not render Avatar 1`] = `<span />`;
+
+exports[`Avatar render Avatar 1`] = `
+<span>
+  <img
+    height="20"
+    src="example.png"
+    width="20" />
+</span>
+`;

--- a/front/__tests__/components/__snapshots__/OAuth.spec.js.snap
+++ b/front/__tests__/components/__snapshots__/OAuth.spec.js.snap
@@ -1,0 +1,14 @@
+exports[`OAuth render Signin 1`] = `
+<div>
+  <img
+    height="20"
+    src="example.png"
+    width="20" />
+  <Connect(t) />
+</div>
+`;
+
+exports[`OAuth render Signout 1`] = `
+<Connect(t)
+  provider="github" />
+`;

--- a/front/__tests__/components/__snapshots__/OAuth.spec.js.snap
+++ b/front/__tests__/components/__snapshots__/OAuth.spec.js.snap
@@ -1,14 +1,15 @@
 exports[`OAuth render Signin 1`] = `
 <div>
-  <img
-    height="20"
-    src="example.png"
-    width="20" />
+  <Avatar
+    src="example.png" />
   <Connect(t) />
 </div>
 `;
 
 exports[`OAuth render Signout 1`] = `
-<Connect(t)
-  provider="github" />
+<div>
+  <Avatar />
+  <Connect(t)
+    provider="github" />
+</div>
 `;

--- a/front/client/components/Avatar/index.js
+++ b/front/client/components/Avatar/index.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const Avatar = ({src}) => {
+  const img = src && src.length > 0 ? <img height="20" width="20" src={src} /> : null
+
+  return (
+    <span>{img}</span>
+  )
+}
+
+Avatar.propTypes = {
+  src : React.PropTypes.string,
+}
+
+export default Avatar

--- a/front/client/components/OAuth/index.js
+++ b/front/client/components/OAuth/index.js
@@ -1,19 +1,16 @@
 import React from 'react'
 import { OAuthSignInButton, SignOutButton } from "redux-auth/default-theme"
+import Avatar from '../Avatar'
 
 const OAuth = ({auth}) => {
-  if (auth.getIn(["user", "isSignedIn"])) {
-    return (
-      <div>
-        <img height="20" width="20" src={auth.getIn(["user", "attributes", "image"])} />
-        <SignOutButton />
-      </div>
-    )
-  } else {
-    return (
-      <OAuthSignInButton provider="github" />
-    )
-  }
+  const button = auth.getIn(["user", "isSignedIn"]) ? <SignOutButton /> : <OAuthSignInButton provider="github" />
+
+  return (
+    <div>
+      <Avatar src={auth.getIn(["user", "attributes", "image"])} />
+      {button}
+    </div>
+  )
 }
 
 OAuth.propTypes = {

--- a/front/client/components/OAuth/index.js
+++ b/front/client/components/OAuth/index.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { OAuthSignInButton, SignOutButton } from "redux-auth/default-theme"
+
+const OAuth = ({auth}) => {
+  if (auth.getIn(["user", "isSignedIn"])) {
+    return (
+      <div>
+        <img height="20" width="20" src={auth.getIn(["user", "attributes", "image"])} />
+        <SignOutButton />
+      </div>
+    )
+  } else {
+    return (
+      <OAuthSignInButton provider="github" />
+    )
+  }
+}
+
+OAuth.propTypes = {
+  auth : React.PropTypes.object.isRequired,
+}
+
+export default OAuth

--- a/front/client/constants/RequestUrls.js
+++ b/front/client/constants/RequestUrls.js
@@ -1,3 +1,8 @@
 export default {
-  "communities": "/communities"
+  communities: "/communities",
+  auth: {
+    github        : "/auth/github",
+    facebook      : "/auth/facebook",
+    twitter       : "/auth/twitter",
+  }
 }

--- a/front/client/containers/App/index.js
+++ b/front/client/containers/App/index.js
@@ -1,9 +1,11 @@
 import React, { Component } from 'react'
+import SignIn from '../SignIn'
 
 export default class App extends Component {
   render() {
     return (
       <div>
+        <SignIn />
         {this.props.children}
       </div>
     )

--- a/front/client/containers/SignIn/index.js
+++ b/front/client/containers/SignIn/index.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import OAuth from '../../components/OAuth'
+
+const mapStateToProps = (state, ownProps) => {
+  return {
+    auth: state.auth
+  }
+}
+
+export default connect(mapStateToProps, {})(OAuth)

--- a/front/client/index.js
+++ b/front/client/index.js
@@ -1,21 +1,32 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import { configure } from 'redux-auth'
 import { AppContainer } from 'react-hot-loader'
 import configureStore from './store'
 import { browserHistory } from 'react-router'
 import { syncHistoryWithStore } from 'react-router-redux'
 import Root from './containers/Root'
+import RequestUrls from './constants/RequestUrls'
 
 const state = {}
 const store = configureStore(state, browserHistory)
 const history = syncHistoryWithStore(browserHistory, store)
 
 const renderApp = (RootComponent) => {
-  ReactDOM.render(
-    <AppContainer>
-      <RootComponent store={store} history={history} />
-    </AppContainer>,
-    document.getElementById('root')
+  store.dispatch(configure({
+      apiUrl              : Config.ApiEndPoint,
+      authProviderPaths   : {
+        github    : RequestUrls.auth.github,
+        facebook  : RequestUrls.auth.facebook,
+        twitter   : RequestUrls.auth.twitter
+    }
+  },{clientOnly: true, cleanSession: false})).then(
+    ReactDOM.render(
+      <AppContainer>
+        <RootComponent store={store} history={history} />
+      </AppContainer>,
+      document.getElementById('root')
+    )
   )
 }
 

--- a/front/client/reducers/index.js
+++ b/front/client/reducers/index.js
@@ -1,10 +1,12 @@
 import { combineReducers } from 'redux'
 import { routerReducer } from 'react-router-redux'
+import { authStateReducer } from "redux-auth"
 import Community from './Community'
 import CommunityList from './CommunityList'
 
 export default combineReducers({
   Community,
   CommunityList,
+  auth: authStateReducer,
   routing: routerReducer
 })


### PR DESCRIPTION
### Overview:概要
https://github.com/shinosakarb/tebukuro/issues/18 Added SignIn and SignOut processing by redux-auth

### Technical changes:技術的変更点
nothing.

### Impact point:変更に関する影響箇所
* Add SignIn button to all pages (App Container).
* Controls to display login's image and SignOut button at SignIn.

### Change of UserInterface:UIの変更
before
![image](https://cloud.githubusercontent.com/assets/7520815/23241993/e6f1f158-f9b9-11e6-8cf7-15797250e2ea.png)

after
![image](https://cloud.githubusercontent.com/assets/7520815/23241910/70c89734-f9b9-11e6-8486-7f5d56e39660.png)

![image](https://cloud.githubusercontent.com/assets/7520815/23241956/c090cae8-f9b9-11e6-8e79-a5199ac00f6a.png)
