### PR TITLE
Add event model of front

### DIFF
--- a/front/__tests__/models/Base.spec.js
+++ b/front/__tests__/models/Base.spec.js
@@ -1,17 +1,19 @@
-import Community from '../../client/models/Community'
+import Base from '../../client/models/Base'
 
-describe('Community', () => {
+describe('Base', () => {
   describe('isError', () => {
     describe('when error is not empty', () => {
       it('should return true', () => {
-        const subject = new Community({ errors: ['error'] })
+        const klass = Base({ errors: ['error'] })
+        const subject = new klass()
         expect(subject.isError()).toBe(true)
       })
     })
 
     describe('when error is empty', () => {
       it('should return false', () => {
-        const subject = new Community({ errors: [] })
+        const klass = Base({ errors: [] })
+        const subject = new klass()
         expect(subject.isError()).toBe(false)
       })
     })

--- a/front/__tests__/models/Event.spec.js
+++ b/front/__tests__/models/Event.spec.js
@@ -1,0 +1,39 @@
+import Event from '../../client/models/Event'
+import MockDate from 'mockdate'
+
+describe('Event', () => {
+  describe('isEnd', () => {
+    beforeAll(() => {
+      MockDate.set(new Date('2017/03/02 09:00:00'))
+    })
+    test('event termination', () => {
+      const subject = new Event({eventEndsAt: '2017/03/02 08:59:59'})
+      expect(subject.isEnd()).toBe(true)
+    })
+    test('before the event ends',() => {
+      const subject = new Event({eventEndsAt: '2017/03/02 09:00:00'})
+      expect(subject.isEnd()).toBe(false)
+    })
+  })
+
+  describe('convertEventStartsAtToDate', () => {
+    test('blank eventStartsAt', () => {
+      const subject = new Event({eventStartsAt: ''})
+      expect(subject.convertEventStartsAtToDate()).toBeNull()
+    })
+    test('presence eventStartsAt', () => {
+      const subject = new Event({eventStartsAt: '2017/03/02 09:00:00'})
+      expect(subject.convertEventStartsAtToDate().getTime()).toBe((new Date('2017/03/02 09:00:00')).getTime())
+    })
+  })
+  describe('convertEventEndsAtToDate', () => {
+    test('blank eventEndsAt', () => {
+      const subject = new Event({eventEndsAt: ''})
+      expect(subject.convertEventEndsAtToDate()).toBeNull()
+    })
+    test('presence eventEndsAt', () => {
+      const subject = new Event({eventEndsAt: '2017/03/02 09:00:01'})
+      expect(subject.convertEventEndsAtToDate().getTime()).toBe((new Date('2017/03/02 09:00:01')).getTime())
+    })
+  })
+})

--- a/front/client/models/Base.js
+++ b/front/client/models/Base.js
@@ -1,0 +1,11 @@
+import { Record as originRecord } from 'immutable'
+
+export default (args = {}) => {
+  const base = originRecord({errors: [], ...args})
+
+  return class BaseClass extends base {
+    isError() {
+      return this.errors.length !== 0
+    }
+  }
+}

--- a/front/client/models/Community.js
+++ b/front/client/models/Community.js
@@ -1,14 +1,10 @@
-import { Record } from 'immutable'
+import Record from './Base'
 
 export const CommunityRecord = Record({
   id:           0,
   name:         '',
-  description:  '',
-  errors:       []
+  description:  ''
 })
 
 export default class Community extends CommunityRecord {
-  isError() {
-    return this.errors.length !== 0
-  }
 }

--- a/front/client/models/Event.js
+++ b/front/client/models/Event.js
@@ -1,0 +1,32 @@
+import Record from './Base'
+import { Set } from 'immutable'
+
+export const EventRecord = Record({
+  id:             0,
+  name:           '',
+  description:    '',
+  communityId:    0,
+  eventStartsAt:  '',
+  eventEndsAt:    '',
+  address:        '',
+  tickets:        Set.of()
+})
+
+export default class Event extends EventRecord {
+  setTickets(list) {
+    return this.set('tickets', Set.of(...list))
+  }
+
+  isEnd() {
+    // TODO It depends on the local machine
+    return (new Date()).getTime() > this.convertEventEndsAtToDate().getTime()
+  }
+
+  convertEventStartsAtToDate() {
+    return this.eventStartsAt && this.eventStartsAt.length > 0 ? new Date(this.eventStartsAt) : null
+  }
+
+  convertEventEndsAtToDate() {
+    return this.eventEndsAt && this.eventEndsAt.length > 0 ? new Date(this.eventEndsAt) : null
+  }
+}

--- a/front/client/models/index.js
+++ b/front/client/models/index.js
@@ -1,7 +1,9 @@
 import { CommunityRecord } from '../models/Community'
 import { CommunityListRecord } from '../models/CommunityList'
+import { EventRecord } from '../models/Event'
 
 export const Records = [
   CommunityRecord,
-  CommunityListRecord
+  CommunityListRecord,
+  EventRecord
 ]

--- a/front/package.json
+++ b/front/package.json
@@ -46,6 +46,7 @@
     "jest": "^19.0.2",
     "json-loader": "^0.5.4",
     "koa-webpack": "^0.3.1",
+    "mockdate": "^2.0.1",
     "nock": "^9.0.7",
     "node-sass": "^4.5.0",
     "postcss-loader": "^1.3.2",

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -3540,6 +3540,10 @@ mixin-object@^2.0.1:
   dependencies:
     minimist "0.0.8"
 
+mockdate@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.1.tgz#51bc309e2c4396600d56b6c23a6a0f4182943a36"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"


### PR DESCRIPTION
### Overview:概要
https://github.com/shinosakarb/tebukuro/issues/137 に基づき、フロントのEvent Modelを作成

### Technical changes:技術的変更点
以下のpacakgeを追加
* [mockdate](https://github.com/boblauer/MockDate) 日付をモックするために使用

### Impact point:変更に関する影響箇所
Communityモデルに存在したエラー用のattributeおよびmethodを共通処理としてBaseクラスに作成した。必要な場合はそれをextendsする形にした。

### other
* reducerに関しては、作成は可能だがテストするのにactionが存在した方がいいと思うのでactionと同時に作成する。
* イベントが終了かの判定メソッドではクライアントに依存した時刻で判定しているため、後に変更するかは議論したい。