### PR TITLE
Add event api of front

### DIFF
--- a/front/__tests__/api/Event.spec.js
+++ b/front/__tests__/api/Event.spec.js
@@ -1,0 +1,173 @@
+import nock from 'nock'
+import Event from '../../client/models/Event'
+import * as EventAPI from '../../client/api/Event'
+import RequestUrls from '../../client/constants/RequestUrls'
+
+describe('Event', () => {
+  const id = 1
+  const communityId = 1
+
+  const params = {
+    id: id,
+    community_id: communityId,
+    name: 'eventName',
+    event_starts_at: '2017/03/04 13:00:00',
+    event_ends_at: '2017/03/04 13:00:00',
+    description: 'eventDescription',
+    address: 'eventAddress'
+  }
+
+  const invalidParams = {
+    id: id,
+    community_id: communityId,
+    name: '',
+    event_starts_at: '',
+    event_ends_at: '',
+    description: '',
+    address: ''
+  }
+
+  const nameError = ['を入力してください']
+  const eventStartsAtError = ['を入力してください']
+  const eventEndsAtError = ['を入力してください']
+  const descriptionError = ['を入力してください']
+  const addressError = ['を入力してください']
+
+  const responseError = {
+    nameError: nameError,
+    eventStartsAtError: eventStartsAtError,
+    eventEndsAtError: eventEndsAtError,
+    description: descriptionError,
+    address: addressError
+  }
+
+  describe('createEvent', () => {
+    describe('when valid param', () => {
+      it('should return action', () => {
+
+        nock(Config.ApiEndPoint)
+          .post(`${RequestUrls.communityEvents(communityId)}`)
+          .reply(201, params)
+
+        return EventAPI.createEvent(params)
+          .then((payload) => {
+            expect(payload).toEqual(params)
+          })
+      })
+    })
+
+    describe('when invalid param', () => {
+      it('should return action with error', () => {
+
+        nock(Config.ApiEndPoint)
+          .post(`${RequestUrls.communityEvents(communityId)}`)
+          .reply(422, responseError)
+
+        return EventAPI.createEvent(invalidParams)
+          .catch((payload) => {
+            expect(payload.messages[0]).toContain('name')
+            expect(payload.messages[1]).toContain('eventStartsAt')
+            expect(payload.messages[2]).toContain('eventEndsAt')
+            expect(payload.messages[3]).toContain('description')
+            expect(payload.messages[4]).toContain('address')
+          })
+      })
+    })
+  })
+
+  describe('getEvents', () => {
+    test('get JSON of events', () =>{
+      const response = [
+        {
+          id: id,
+          community_id: communityId,
+          name: 'eventName1',
+          event_starts_at: '2017/03/04 13:00:00',
+          event_ends_at: '2017/03/04 17:00:00',
+          description: 'eventDescription',
+          address: 'eventAddress'
+        },
+        {
+          id: 2,
+          community_id: 2,
+          name: 'eventName2',
+          event_starts_at: '2017/05/27 10:00:00',
+          event_ends_at: '2017/05/27 18:00:00',
+          description: "eventDescription2",
+          address: "eventAddress2"
+        }
+      ]
+
+      nock(Config.ApiEndPoint)
+        .get(`${RequestUrls.communityEvents(communityId)}`)
+        .reply(200, response)
+
+      return EventAPI.getEvents(communityId)
+        .then((payload) => {
+          expect(payload).toEqual(response)
+        })
+    })
+  })
+
+  describe('showEvent', () => {
+    test('get JSON of a event', () =>{
+
+      nock(Config.ApiEndPoint)
+        .get(`${RequestUrls.events}/${params.id}`)
+        .reply(200, params)
+
+      return EventAPI.showEvent(id)
+        .then((payload) => {
+          expect(payload).toEqual(params)
+        })
+    })
+  })
+
+  describe('editEvent', () => {
+    describe('when valid param', () => {
+      it('should return action', () => {
+  
+        nock(Config.ApiEndPoint)
+          .intercept(`${RequestUrls.events}/${params.id}`, 'PATCH')
+          .reply(200, params)
+  
+        return EventAPI.editEvent(params)
+          .then((payload) => {
+            expect(payload).toEqual(params)
+          })
+      })
+    })
+
+    describe('when invalid param', () => {
+      it('should return action with error', () => {
+
+        nock(Config.ApiEndPoint)
+          .intercept(`${RequestUrls.events}/${params.id}`, 'PATCH')
+          .reply(422, responseError)
+
+        return EventAPI.editEvent(invalidParams)
+          .catch((payload) => {
+            expect(payload.messages[0]).toContain('name')
+            expect(payload.messages[1]).toContain('eventStartsAt')
+            expect(payload.messages[2]).toContain('eventEndsAt')
+            expect(payload.messages[3]).toContain('description')
+            expect(payload.messages[4]).toContain('address')
+          })
+      })
+    })
+  })
+
+  describe('deleteEvent', () => {
+    test('delete a event', () =>{
+  
+      nock(Config.ApiEndPoint)
+        .intercept(`${RequestUrls.events}/${params.id}`, 'DELETE')
+        .reply(200)
+
+      return EventAPI.deleteEvent(id)
+        .then((payload) => {
+          expect(payload).toEqual({})
+        })
+    })
+  })
+})

--- a/front/client/api/Event.js
+++ b/front/client/api/Event.js
@@ -1,0 +1,22 @@
+import RequestUrls from '../constants/RequestUrls'
+import ApiClient from '../utils/ApiClient'
+
+export const createEvent = (params) => {
+  return ApiClient.post(`${RequestUrls.communityEvents(params.community_id)}`, params)
+}
+
+export const getEvents = (communityId) => {
+  return ApiClient.get(`${RequestUrls.communityEvents(communityId)}`)
+}
+
+export const showEvent = (id) => {
+  return ApiClient.get(`${RequestUrls.events}/${id}`)
+}
+
+export const editEvent = (params) => {
+  return ApiClient.patch(`${RequestUrls.events}/${params.id}`, params)
+}
+
+export const deleteEvent = (id) => {
+  return ApiClient.delete(`${RequestUrls.events}/${id}`)
+}

--- a/front/client/api/__mocks__/Event.js
+++ b/front/client/api/__mocks__/Event.js
@@ -1,0 +1,13 @@
+const path = require('path')
+const Event = jest.genMockFromModule('../Event')
+
+let mockResult = Object.create(null)
+export const __setMockResult = (normal = true) => {
+  mockResult = normal
+}
+
+export const showEvent = (id) => mockResult ? Promise.resolve({message: "normal mock"}) : Promise.reject({message: "error mock"})
+export const createEvent = require('../Event').createEvent
+export const getEvents = require('../Event').getEvents
+export const editEvent = require('../Event').editEvent
+export const deleteEvent = require('../Event').deleteEvents

--- a/front/client/constants/RequestUrls.js
+++ b/front/client/constants/RequestUrls.js
@@ -1,5 +1,9 @@
 export default {
   communities: "/communities",
+  events: "/events",
+  communityEvents: (community_id) => {
+    return `/communities/${community_id}/events`
+  },
   auth: {
     github        : "/auth/github",
     facebook      : "/auth/facebook",


### PR DESCRIPTION
### Overview:概要
#140 に基づいて、フロント側のEvent APIを作成した。
下記のメソッドを実装し、テストコードを作成して、`npm run test`がパスする事を確認した。
- createEvent
- getEvents
- showEvent
- editEvent
- deleteEvent

また、Base ModelにtoRequestParamsメソッドを追加して引数で指定されたプロパティを持つオブジェクトを出力する機能を実装した。

### Technical changes:技術的変更点
基本的にCommunity APIと同様の構造で作成した。
APIに送信するプロパティ名をtoRequestParamsにてcamel caseからsnake caseに変換するため、change caseパッケージを追加した。
endpointについては下記のconfig/route.rbの内容に従ってアクセスするよう設定した。
```
community_events GET      /communities/:community_id/events(.:format) events#index {:format=>"json"}
                POST     /communities/:community_id/events(.:format) events#create {:format=>"json"}
                event GET      /events/:id(.:format)                       events#show {:format=>"json"}
                      PATCH    /events/:id(.:format)                       events#update {:format=>"json"}
                      PUT      /events/:id(.:format)                       events#update {:format=>"json"}
                      DELETE   /events/:id(.:format)                       events#destroy {:format=>"json"}
```

### Impact point:変更に関する影響箇所
なし

###other
- community_idはAPIのメソッド呼び出し時の引数としています
- editおよびdelete成功時のstatus codeは200と仮定してします
- deleteEventのテストではstatus codeの確認ができないので、空のオブジェクトが返ってくること（エラーメッセージがないこと）を確認項目としています
- テスト時のmockは使用されていない認識です