### PR TITLE
Add reducer of ticket

### DIFF
--- a/front/__tests__/reducers/Event.spec.js
+++ b/front/__tests__/reducers/Event.spec.js
@@ -20,6 +20,26 @@ describe('Event', () => {
       const eventStartsAt = '2017/03/02 09:00:00'
       const eventEndsAt = '2017/03/02 12:00:00'
       const address = 'address'
+      const tickets = [
+        {
+          id:             3,
+          name:           'ticketName1',
+          cost:           4,
+          quantity:       5,
+          event_id:       6,
+          sale_starts_at: '2017/03/01 09:00:00',
+          sale_ends_at:   '2017/03/01 10:30:00'
+        },
+        {
+          id:             7,
+          name:           'ticketName2',
+          cost:           8,
+          quantity:       9,
+          event_id:       10,
+          sale_starts_at: '2017/03/01 10:30:00',
+          sale_ends_at:   '2017/03/01 12:00:00'
+        }
+      ]
 
       const response = {
         id: id,
@@ -28,7 +48,8 @@ describe('Event', () => {
         community_id: communityId,
         event_starts_at: eventStartsAt,
         event_ends_at: eventEndsAt,
-        address: address
+        address: address,
+        tickets: tickets
       }
 
       const subject = EventReducer(model(), createEvent(response))
@@ -40,6 +61,19 @@ describe('Event', () => {
       expect(subject.eventStartsAt).toBe(response.event_starts_at)
       expect(subject.eventEndsAt).toBe(response.event_ends_at)
       expect(subject.address).toBe(response.address)
+
+      expect(subject.tickets.count()).toBe(2)
+      let index = 0
+      subject.tickets.forEach((ticket) => {
+        expect(ticket.id).toBe(tickets[index].id)
+        expect(ticket.name).toBe(tickets[index].name)
+        expect(ticket.cost).toBe(tickets[index].cost)
+        expect(ticket.quantity).toBe(tickets[index].quantity)
+        expect(ticket.eventId).toBe(tickets[index].event_id)
+        expect(ticket.saleStartsAt).toBe(tickets[index].sale_starts_at)
+        expect(ticket.saleEndsAt).toBe(tickets[index].sale_ends_at)
+        index += 1
+      })
     })
 
     it("should handle CREATE_EVENT error", () => {

--- a/front/__tests__/reducers/Ticket.spec.js
+++ b/front/__tests__/reducers/Ticket.spec.js
@@ -1,0 +1,53 @@
+import { createAction } from 'redux-actions'
+import TicketReducer    from '../../client/reducers/Ticket'
+import ApiResponseError from '../../client/utils/ApiResponseError'
+import Actions          from '../../client/constants/Actions'
+import TicketModel      from '../../client/models/Ticket'
+
+const model = (params) => {
+  return new TicketModel(params)
+}
+
+describe('Ticket', () => {
+  describe('CREATE_TICKET', () => {
+    const createTicket = createAction(Actions.Ticket.createTicket)
+
+    it("should handle CREATE_TICKET", () => {
+      const id            = 1
+      const name          = 'communityName'
+      const description   = 'communityDescription'
+      const cost          = 2
+      const quantity      = 3
+      const eventId       = 4
+      const saleStartsAt  = '2017/03/02 09:00:00'
+      const saleEndsAt    = '2017/03/02 11:00:00'
+
+      const response = {
+        id:             id,
+        name:           name,
+        cost:           cost,
+        quantity:       quantity,
+        event_id:       eventId,
+        sale_starts_at: saleStartsAt,
+        sale_ends_at:   saleEndsAt
+      }
+
+      const subject = TicketReducer(model(), createTicket(response))
+
+      expect(subject.id).toBe(response.id)
+      expect(subject.name).toBe(response.name)
+      expect(subject.cost).toBe(response.cost)
+      expect(subject.quantity).toBe(response.quantity)
+      expect(subject.eventId).toBe(response.event_id)
+      expect(subject.saleStartsAt).toBe(response.sale_starts_at)
+      expect(subject.saleEndsAt).toBe(response.sale_ends_at)
+    })
+
+    it("should handle CREATE_TICKET error", () => {
+      const errorMessage = 'error'
+      const action = createTicket(new ApiResponseError([errorMessage]))
+      const subject = TicketReducer(model(), action)
+      expect(subject.errors[0]).toBe(errorMessage)
+    })
+  })
+})

--- a/front/client/constants/Actions.js
+++ b/front/client/constants/Actions.js
@@ -7,5 +7,8 @@ export default {
   },
   Event: {
     createEvent: "CREATE_EVENT"
+  },
+  Ticket: {
+    createTicket: "CREATE_TICKET"
   }
 }

--- a/front/client/reducers/Event.js
+++ b/front/client/reducers/Event.js
@@ -1,12 +1,13 @@
-import { handleActions }  from 'redux-actions'
-import Event              from '../models/Event'
+import { handleActions }    from 'redux-actions'
+import Event                from '../models/Event'
+import { ticketReducerMap } from './Ticket'
 
 export const eventInitialState = new Event()
 
 export const eventReducerMap = {
   CREATE_EVENT: {
     next: (state, action) => {
-      return new Event({
+      const event = new Event({
         id:             action.payload.id,
         name:           action.payload.name,
         description:    action.payload.description,
@@ -15,6 +16,14 @@ export const eventReducerMap = {
         eventEndsAt:    action.payload.event_ends_at,
         address:        action.payload.address
       })
+      return event.setTickets(
+        action.payload.tickets ? action.payload.tickets.map((item) => {
+          return ticketReducerMap.CREATE_TICKET.next(
+            null,
+            {payload: item}
+          )
+        }) : []
+      )
     },
     throw: (state, action) => {
       return new Event({

--- a/front/client/reducers/Ticket.js
+++ b/front/client/reducers/Ticket.js
@@ -1,0 +1,27 @@
+import { handleActions }  from 'redux-actions'
+import Ticket             from '../models/Ticket'
+
+export const ticketInitialState = new Ticket()
+
+export const ticketReducerMap = {
+  CREATE_TICKET: {
+    next: (state, action) => {
+      return new Ticket({
+        id:           action.payload.id,
+        name:         action.payload.name,
+        cost:         action.payload.cost,
+        quantity:     action.payload.quantity,
+        eventId:      action.payload.event_id,
+        saleStartsAt: action.payload.sale_starts_at,
+        saleEndsAt:   action.payload.sale_ends_at
+      })
+    },
+    throw: (state, action) => {
+      return new Ticket({
+        errors: action.payload.messages
+      })
+    }
+  }
+}
+
+export default handleActions(ticketReducerMap, ticketInitialState)


### PR DESCRIPTION
### Overview:概要
https://github.com/shinosakarb/tebukuro/issues/138 に基づき、TicketのReducerを作成

### Technical changes:技術的変更点
Event Reducerで紐づく、Ticketsが存在する場合は合わせて作成するように変更。

### Impact point:変更に関する影響箇所
Event Reducerの変更を行っため、該当箇所のみ影響（ただし、現状は使用されていない）

### other
連想配列のキーがAPIからはスネークケースで来るがJS側はキャメルケースで持っているので
それの変換関数を後で作成し、リファクタリングします。（現状ソースが見苦しい）