### PR TITLE
Remove installing yarn from front-end Dockerfile

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,7 +1,5 @@
-FROM node:7.3.0-alpine
+FROM node:7-alpine
 
-RUN apk update && apk upgrade && apk add --update --no-cache python gcc g++ make
-RUN npm install -g yarn
 RUN mkdir /front_app
 WORKDIR /front_app
 ADD package.json /front_app/package.json

--- a/front/client/api/__mocks__/Community.js
+++ b/front/client/api/__mocks__/Community.js
@@ -7,5 +7,3 @@ export const __setMockResult = (normal = true) => {
 }
 
 export const showCommunity = (id) => mockResult ? Promise.resolve({message: "normal mock"}) : Promise.reject({message: "error mock"})
-export const createCommunity = require('../Community').createCommunity
-export const getCommunities = require('../Community').getCommunities

--- a/front/client/api/__mocks__/Event.js
+++ b/front/client/api/__mocks__/Event.js
@@ -7,7 +7,3 @@ export const __setMockResult = (normal = true) => {
 }
 
 export const showEvent = (id) => mockResult ? Promise.resolve({message: "normal mock"}) : Promise.reject({message: "error mock"})
-export const createEvent = require('../Event').createEvent
-export const getEvents = require('../Event').getEvents
-export const editEvent = require('../Event').editEvent
-export const deleteEvent = require('../Event').deleteEvent


### PR DESCRIPTION
### Overview:概要
remove installing yarn from Dockerfile because Official docker imsage is supported yarn.

### Impact point:変更に関する影響箇所
changed docker image.

### check point
* run `bin/docker setup`
* run `bin/docker start`
* [x] should access `localhost:4000`