### PR TITLE
Refactoring RSpec factories by removing blank elements

### DIFF
--- a/spec/factories/communities.rb
+++ b/spec/factories/communities.rb
@@ -5,19 +5,4 @@ FactoryGirl.define do
     description 'Description'
   end
 
-  factory :community_name_blank, class: Community do
-    name nil
-    description 'Description'
-  end
-
-  factory :community_description_blank, class: Community do
-    name 'name'
-    description nil
-  end
-
-  factory :community_blank, class: Community do
-    name nil
-    description nil
-  end
-  
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -19,32 +19,4 @@ FactoryGirl.define do
     partial_event_detail_information
   end
 
-  factory :event_name_blank, class: Event do
-    name nil
-    description {generate :description}
-    address { ForgeryJa(:address).full_address }
-    partial_event_detail_information
-  end
-
-  factory :event_description_blank, class: Event do
-    name {generate :name}
-    description nil
-    address { ForgeryJa(:address).full_address }
-    partial_event_detail_information
-  end
-
-  factory :event_address_blank, class: Event do
-    name {generate :name}
-    description {generate :description}
-    address nil
-    partial_event_detail_information
-  end
-
-  factory :event_blank, class: Event do
-    name nil
-    description nil
-    address nil
-    partial_event_detail_information
-  end
-
 end

--- a/spec/factories/tickets.rb
+++ b/spec/factories/tickets.rb
@@ -19,32 +19,4 @@ FactoryGirl.define do
     partial_ticket_detail_information
   end
 
-  factory :ticket_name_blank, class: Ticket do
-    name nil
-    cost {generate :cost}
-    quantity {generate :quantity}
-    partial_ticket_detail_information
-  end
-
-  factory :ticket_cost_blank, class: Ticket do
-    name {generate :name}
-    cost nil
-    quantity {generate :quantity}
-    partial_event_detail_information
-  end
-
-  factory :ticket_quantity_blank, class: Ticket do
-    name {generate :name}
-    cost {generate :cost}
-    quantity nil
-    partial_event_detail_information
-  end
-
-  factory :ticket_blank, class: Event do
-    name nil
-    cost nil
-    quantity nil
-    partial_event_detail_information
-  end
-
 end

--- a/spec/requests/communities_spec.rb
+++ b/spec/requests/communities_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Communities(コミュニティーAPI)', type: :request do
 
       context 'nameが未記入' do
 
-        let(:community_name_blank_params) { {community: FactoryGirl.attributes_for(:community_name_blank)} }
+        let(:community_name_blank_params) { {community: FactoryGirl.attributes_for(:community, name: nil)} }
         before do
           post communities_path, params: community_name_blank_params
         end
@@ -86,7 +86,7 @@ RSpec.describe 'Communities(コミュニティーAPI)', type: :request do
 
       context 'descriptionが未記入' do
 
-        let(:community_description_blank_params) { {community: FactoryGirl.attributes_for(:community_description_blank)} }
+        let(:community_description_blank_params) { {community: FactoryGirl.attributes_for(:community, description: nil)} }
         before do
           post communities_path, params: community_description_blank_params
         end
@@ -100,7 +100,7 @@ RSpec.describe 'Communities(コミュニティーAPI)', type: :request do
 
       context 'name, descriptionが未記入' do
 
-        let(:community_blank_params) { {community: FactoryGirl.attributes_for(:community_blank)} }
+        let(:community_blank_params) { {community: FactoryGirl.attributes_for(:community, name: nil, description: nil)} }
         before do
           post communities_path, params: community_blank_params
         end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
     context '異常系' do
 
       context 'nameが未記入' do
-        let(:event_name_blank_params) { {event: FactoryGirl.attributes_for(:event_name_blank)} }
+        let(:event_name_blank_params) { {event: FactoryGirl.attributes_for(:event, name: nil)} }
         before do
           post community_events_path(community), params: event_name_blank_params
         end
@@ -100,7 +100,7 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
       end
 
       context 'descriptionが未記入' do
-        let(:event_description_blank_params) { {event: FactoryGirl.attributes_for(:event_description_blank)} }
+        let(:event_description_blank_params) { {event: FactoryGirl.attributes_for(:event, description: nil)} }
 
         before do
           post community_events_path(community), params: event_description_blank_params
@@ -116,7 +116,7 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
       end
 
       context 'name, descriptionが未記入' do
-        let(:event_blank_params) { {event: FactoryGirl.attributes_for(:event_blank)} }
+        let(:event_blank_params) { {event: FactoryGirl.attributes_for(:event, name: nil, description: nil)} }
         before do
           post community_events_path(community), params: event_blank_params
         end

--- a/spec/requests/tickets_spec.rb
+++ b/spec/requests/tickets_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'Tickets(チケットAPI)', type: :request do
     context '異常系' do
 
       context 'nameが未記入' do
-        let(:ticket_name_blank_params) { {ticket: FactoryGirl.attributes_for(:ticket_name_blank)} }
+        let(:ticket_name_blank_params) { {ticket: FactoryGirl.attributes_for(:ticket, name: nil)} }
         before do
           post event_tickets_path(event), params: ticket_name_blank_params
         end
@@ -99,7 +99,7 @@ RSpec.describe 'Tickets(チケットAPI)', type: :request do
       end
 
       context 'costが未記入' do
-        let(:ticket_cost_blank_params) { {ticket: FactoryGirl.attributes_for(:ticket_cost_blank)} }
+        let(:ticket_cost_blank_params) { {ticket: FactoryGirl.attributes_for(:ticket, cost: nil)} }
 
         before do
           post event_tickets_path(event), params: ticket_cost_blank_params
@@ -115,7 +115,7 @@ RSpec.describe 'Tickets(チケットAPI)', type: :request do
       end
 
       context 'quantityが未記入' do
-        let(:ticket_quantity_blank_params) { {ticket: FactoryGirl.attributes_for(:ticket_quantity_blank)} }
+        let(:ticket_quantity_blank_params) { {ticket: FactoryGirl.attributes_for(:ticket, quantity: nil)} }
         before do
           post event_tickets_path(event), params: ticket_quantity_blank_params
         end
@@ -133,7 +133,7 @@ RSpec.describe 'Tickets(チケットAPI)', type: :request do
     end
 
     context 'name, cost, quantityが未記入' do
-      let(:ticket_blank_params) { {ticket: FactoryGirl.attributes_for(:ticket_blank)} }
+      let(:ticket_blank_params) { {ticket: FactoryGirl.attributes_for(:ticket, name: nil, cost: nil, quantity: nil)} }
       before do
         post event_tickets_path(event), params: ticket_blank_params
       end


### PR DESCRIPTION
### Overview:概要
今後のメンテナンスコストの増大を防ぐため、RSpecのfactory の定義をリファクタリングしてシンプルにする

### Technical changes:技術的変更点
- 変更内容：
  factoryで各属性が空白の場合のモデルを定義していたが、factoryの定義は１つだけとし、各テストケースにおいて対象の属性にnilを指定する

- 変更対象:
  community, event, ticketのAPIへのPOSTリクエストのテスト（他の箇所でエラーケース用のfactoryを使用している箇所はなし）

### Impact point:変更に関する影響箇所
テストのリファクタリングのため無し

### Change of UserInterface:UIの変更
テストのリファクタリングのため無し