### PR TITLE
Fix called create API when show API success

### DIFF
--- a/front/client/actions/Event.js
+++ b/front/client/actions/Event.js
@@ -7,5 +7,5 @@ import ActionDispatch from '../utils/ActionDispatch'
 export const createEvent = createAction(Actions.Event.createEvent, createAPI)
 
 export const showEvent = (id) => {
-  return ActionDispatch.executeApi(showAPI, id, createEvent, errorUrls.pageNotFound)
+  return ActionDispatch.executeApi(showAPI, id, createAction(Actions.Event.createEvent), errorUrls.pageNotFound)
 }


### PR DESCRIPTION
### Overview:概要
現在の(Eventの)show action成功時にcreate用のAPIを実行してしまう不具合修正

### Technical changes:技術的変更点
なし

### Impact point:変更に関する影響箇所
修正したactionは現状使用されていない。
しかし、使用した場合に既存の`createEvent`を使用しているため、API呼び出しを行ってしまうため
API呼び出しを行わないactionのファンクションに変更。
