### PR TITLE
Add moment-timezone.js to prevent the failure of frontend test

### DIFF
--- a/front/__tests__/components/__snapshots__/TicketList.spec.js.snap
+++ b/front/__tests__/components/__snapshots__/TicketList.spec.js.snap
@@ -18,11 +18,11 @@ exports[`TicketList render list of tickets 1`] = `
     // TODO: These Date object strings should be formatted.
     <p>
       saleStartsAt: 
-      Wed Mar 01 2017 18:00:00 GMT+0900 (JST)
+      2017-03-01T09:00:00Z
     </p>
     <p>
       saleEndsAt: 
-      Wed Mar 01 2017 19:30:00 GMT+0900 (JST)
+      2017-03-01T10:30:00Z
     </p>
   </li>
   <li>
@@ -41,11 +41,11 @@ exports[`TicketList render list of tickets 1`] = `
     // TODO: These Date object strings should be formatted.
     <p>
       saleStartsAt: 
-      Mon Dec 11 2017 22:30:00 GMT+0900 (JST)
+      2017-12-11T13:30:00Z
     </p>
     <p>
       saleEndsAt: 
-      Tue Dec 12 2017 00:00:00 GMT+0900 (JST)
+      2017-12-11T15:00:00Z
     </p>
   </li>
 </ul>

--- a/front/__tests__/models/Base.spec.js
+++ b/front/__tests__/models/Base.spec.js
@@ -84,6 +84,11 @@ describe('Base', () => {
   })
   
   describe('formatDateWith', () => {
+    afterEach(() => {
+      // Timezone should be restored to UTC, for in case of the failing test that is changing timezone.
+      moment.tz.setDefault('UTC')
+    })
+
     test('non existent attribute', () => {
       const subject = subjectClass({eventStartsAt: ''})
       expect(subject.formatDateWith('eventEndsAt')).toBeNull()
@@ -98,7 +103,6 @@ describe('Base', () => {
       moment.tz.setDefault('Asia/Tokyo')
       const subject = subjectClass({eventStartsAt: '2017-03-02T09:00:00.000Z'})
       expect(subject.formatDateWith('eventStartsAt').toString()).toBe('2017-03-02T18:00:00+09:00')
-      moment.tz.setDefault('UTC')
     })
 
     test('presence eventStartsAt in UTC', () => {

--- a/front/__tests__/models/Base.spec.js
+++ b/front/__tests__/models/Base.spec.js
@@ -1,5 +1,6 @@
 import Base from '../../client/models/Base'
 import MockDate from 'mockdate'
+import moment from 'moment-timezone'
 
 const subjectClass = (params) => {
   const klass = Base(params)
@@ -78,7 +79,31 @@ describe('Base', () => {
 
     test('presence eventStartsAt', () => {
       const subject = subjectClass({eventStartsAt: '2017/03/02 09:00:00'})
-      expect(subject.makeDateWith('eventStartsAt').getTime()).toBe((new Date('2017/03/02 09:00:00')).getTime())
+      expect(subject.makeDateWith('eventStartsAt').getTime()).toBe((new Date()).getTime())
+    })
+  })
+  
+  describe('formatDateWith', () => {
+    test('non existent attribute', () => {
+      const subject = subjectClass({eventStartsAt: ''})
+      expect(subject.formatDateWith('eventEndsAt')).toBeNull()
+    })
+
+    test('blank eventStartsAt', () => {
+      const subject = subjectClass({eventStartsAt: ''})
+      expect(subject.formatDateWith('eventStartsAt')).toBeNull()
+    })
+
+    test('presence eventStartsAt in JST', () => {
+      moment.tz.setDefault('Asia/Tokyo')
+      const subject = subjectClass({eventStartsAt: '2017-03-02T09:00:00.000Z'})
+      expect(subject.formatDateWith('eventStartsAt').toString()).toBe('2017-03-02T18:00:00+09:00')
+      moment.tz.setDefault('UTC')
+    })
+
+    test('presence eventStartsAt in UTC', () => {
+      const subject = subjectClass({eventStartsAt: '2017-03-02T09:00:00.000Z'})
+      expect(subject.formatDateWith('eventStartsAt').toString()).toBe('2017-03-02T09:00:00Z')
     })
   })
 })

--- a/front/client/components/TicketList/index.js
+++ b/front/client/components/TicketList/index.js
@@ -11,8 +11,8 @@ const TicketList = ({tickets}) => {
               <p>cost: { ticket.cost }</p>
               <p>quantity: { ticket.quantity }</p>
               // TODO: These Date object strings should be formatted.
-              <p>saleStartsAt: { ticket.makeDateWith('saleStartsAt').toString() }</p>
-              <p>saleEndsAt: { ticket.makeDateWith('saleEndsAt').toString() }</p>
+              <p>saleStartsAt: { ticket.formatDateWith('saleStartsAt') }</p>
+              <p>saleEndsAt: { ticket.formatDateWith('saleEndsAt') }</p>
             </li>
           )
         })

--- a/front/client/models/Base.js
+++ b/front/client/models/Base.js
@@ -1,4 +1,5 @@
 import { Record as originRecord } from 'immutable'
+import moment from 'moment'
 
 export default (args = {}) => {
   const base = originRecord({errors: [], ...args})
@@ -20,6 +21,10 @@ export default (args = {}) => {
 
     makeDateWith(attribute) {
       return this.get(attribute) && this.get(attribute).length > 0 ? new Date(this.get(attribute)) : null
+    }
+  
+    formatDateWith(attribute) {
+      return this.makeDateWith(attribute) ? moment(this.makeDateWith(attribute)).format() : null
     }
   }
 }

--- a/front/config/jest/setup.js
+++ b/front/config/jest/setup.js
@@ -1,0 +1,3 @@
+// Default timezone for frontend tests is UTC. 
+import moment from 'moment-timezone'
+moment.tz.setDefault('UTC')

--- a/front/package.json
+++ b/front/package.json
@@ -47,6 +47,8 @@
     "json-loader": "^0.5.4",
     "koa-webpack": "^0.3.1",
     "mockdate": "^2.0.1",
+    "moment": "^2.17.1",
+    "moment-timezone": "^0.5.11",
     "nock": "^9.0.7",
     "node-sass": "^4.5.0",
     "postcss-loader": "^1.3.2",
@@ -65,6 +67,7 @@
     "transform": {
       "^.+\\.js$": "<rootDir>/node_modules/babel-jest",
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileTransformer.js"
-    }
+    },
+    "setupTestFrameworkScriptFile": "<rootDir>/config/jest/setup.js"
   }
 }

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -3544,6 +3544,16 @@ mockdate@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.1.tgz#51bc309e2c4396600d56b6c23a6a0f4182943a36"
 
+moment-timezone@^0.5.11:
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.11.tgz#9b76c03d8ef514c7e4249a7bbce649eed39ef29f"
+  dependencies:
+    moment ">= 2.6.0"
+
+"moment@>= 2.6.0", moment@^2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.1.tgz#fed9506063f36b10f066c8b59a144d7faebe1d82"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"


### PR DESCRIPTION
### Overview:概要
Issue #165 のローカル環境のタイムゾーン設定により日付の表示が変わる問題への対策として、moment-timezone.jsを導入する。
moment-timezone.jsによりテスト時のタイムゾーンを固定して時刻表示を統一することでテストの失敗を防ぐ。

### Technical changes:技術的変更点
- moment.js および moment-timezone.js をパッケージに追加
- Baseモデルにmomentオブジェクトから日時を返すメソッドを追加
- momentのデフォルトのタイムゾーンをUTCに設定するスクリプトを追加し、Jestの起動時に実行する設定をpackage.jsonに追加
- TicketListのsaleStartsAtとsaleEndsAtは追加したメソッドによりmomentを利用して日時を出力する

### Impact point:変更に関する影響箇所
テスト時はmomentオブジェクトを使用した場合、ローカル環境に関係なくUTCで時刻が出力される。通常のDateオブジェクトについてはこれまで同様、ローカル環境のタイムゾーンに依存した時刻が出力される。

### Change of UserInterface:UIの変更
TicketListは日時の表示形式が変更となるが、現時点では表示フォーマットが未定のためスクリーンショットは割愛する。

### Others
- Baseモデルに追加したメソッドのテストではタイムゾーンをJSTに設定した場合もテストしています。
- PR上では提示できませんが、ローカル環境（JST）とDocker環境（UTC）でそれぞれテストを実行して同じ結果になることを確認しています。