### PR TITLE
Fix validation propTypes of TicketList component to check the Set object

### DIFF
--- a/front/__tests__/components/TicketList.spec.js
+++ b/front/__tests__/components/TicketList.spec.js
@@ -1,8 +1,9 @@
-import React from 'react'
-import { shallow } from 'enzyme'
+import React         from 'react'
+import { Set }       from 'immutable'
+import { shallow }   from 'enzyme'
 import shallowToJson from 'enzyme-to-json'
-import TicketModel from '../../client/models/Ticket'
-import TicketList from '../../client/components/TicketList'
+import TicketModel   from '../../client/models/Ticket'
+import TicketList    from '../../client/components/TicketList'
 
 const model = (params) => {
   return new TicketModel(params)
@@ -31,9 +32,10 @@ describe('TicketList', () => {
       }
     ]
 
-    const tickets = ticketsParams.map((params) => model(params))
+    const ticketsModel = ticketsParams.map((params) => model(params))
+    const ticketsSet = Set.of(...ticketsModel) 
 
-    const component = shallow(<TicketList tickets={ tickets } />)
+    const component = shallow(<TicketList tickets={ ticketsSet } />)
 
     const tree = shallowToJson(component)
     expect(tree).toMatchSnapshot()

--- a/front/client/components/TicketList/index.js
+++ b/front/client/components/TicketList/index.js
@@ -1,4 +1,5 @@
 import React     from 'react'
+import { Set }   from 'immutable'
 
 const TicketList = ({tickets}) => {
   return (
@@ -22,7 +23,7 @@ const TicketList = ({tickets}) => {
 }
 
 TicketList.propTypes = {
-  tickets: React.PropTypes.arrayOf(React.PropTypes.object).isRequired
+  tickets: React.PropTypes.instanceOf(Set).isRequired
 }
 
 export default TicketList


### PR DESCRIPTION
### Overview:概要
TicketListのcomponentは入力パラメータ(propTypes)に対してArrayであることをチェックしている。
しかしEventModelのticketsはSetオブジェクトのため、TicketListコンポーネントのpropに設定した場合にバリデーションエラーの警告が出力される。

![screenshot from 2017-03-13 12-21-16](https://cloud.githubusercontent.com/assets/10824691/23879715/2c96d994-0892-11e7-88d4-6ac2fe34009c.png)

このため、TicketListコンポーネントではSetオブジェクトであることをチェックするよう変更する。

### Technical changes:技術的変更点
TicketListコンポーネントでimmutable.jsのSetオブジェクトをインポートする
Arrayオブジェクト、Setオブジェクトともにmap関数を使用するため、render()メソッドの変更はなし。

### Impact point:変更に関する影響箇所
none

### Change of UserInterface:UIの変更
none

### Others
添付した画面は作業中のEventコンテナのテストの画面からキャプチャしたため、現在の環境では再現いたしません。ただしReducerではEventモデルをstoreに保存するため、この変更が必要と考えています。