### PR TITLE
Use json-api adapter for error render

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,18 @@ class ApplicationController < ActionController::API
 
   protected
 
-  def not_found
-    render json: { errors: 'Not found' }, status: :not_found
+  def not_found(exception)
+    model = build_not_found_model(exception.model)
+    render_error(model, :not_found)
+  end
+
+  def build_not_found_model(model_name)
+    model = model_name.classify.constantize.new
+    model.errors.add(:id, 'Not found')
+    model
+  end
+
+  def render_error(model, status)
+    render json: model, status: status, adapter: :json_api, serializer: ActiveModel::Serializer::ErrorSerializer
   end
 end


### PR DESCRIPTION
### Overview:概要
404のレスポンスもJSON APIのAdapterを使うように修正

### Technical changes:技術的変更点
404のレスポンス
```
e.g.
{"errors"=>[{"source"=>{"pointer"=>"/data/attributes/id"}, "detail"=>"Not found"}]}
```

### Impact point:変更に関する影響箇所
404のレスポンス

### Reference document
[ActiveModelSerializers JSON API errors](https://github.com/rails-api/active_model_serializers/blob/master/docs/jsonapi/errors.md)