### PR TITLE
Add converter between snake case and camel case

### DIFF
--- a/front/__tests__/models/Base.spec.js
+++ b/front/__tests__/models/Base.spec.js
@@ -110,4 +110,24 @@ describe('Base', () => {
       expect(subject.formatDateWith('eventStartsAt').toString()).toBe('2017-03-02T09:00:00Z')
     })
   })
+
+  describe('camelKeysOf', () => {
+
+    const camelKeysParams = {
+      name: 'name',
+      eventStartsAt: '2017-03-04 13:00',
+      eventEndsAt: '2017-03-04 17:00'
+    }
+
+    const snakeKeysParams = {
+      name: 'name',
+      event_starts_at: '2017-03-04 13:00',
+      event_ends_at: '2017-03-04 17:00'
+    }
+
+    it('converts snake case to camel case', () => {
+      const subject = subjectClass({})
+      expect(subject.camelKeysOf(snakeKeysParams)).toEqual(camelKeysParams)
+    })
+  })
 })

--- a/front/__tests__/models/Base.spec.js
+++ b/front/__tests__/models/Base.spec.js
@@ -1,6 +1,7 @@
-import Base from '../../client/models/Base'
-import MockDate from 'mockdate'
-import moment from 'moment-timezone'
+import Base        from '../../client/models/Base'
+import ConvertCase from '../../client/utils/ConvertCase'
+import MockDate    from 'mockdate'
+import moment      from 'moment-timezone'
 
 const subjectClass = (params) => {
   const klass = Base(params)
@@ -108,26 +109,6 @@ describe('Base', () => {
     test('presence eventStartsAt in UTC', () => {
       const subject = subjectClass({eventStartsAt: '2017-03-02T09:00:00.000Z'})
       expect(subject.formatDateWith('eventStartsAt').toString()).toBe('2017-03-02T09:00:00Z')
-    })
-  })
-
-  describe('camelKeysOf', () => {
-
-    const camelKeysParams = {
-      name: 'name',
-      eventStartsAt: '2017-03-04 13:00',
-      eventEndsAt: '2017-03-04 17:00'
-    }
-
-    const snakeKeysParams = {
-      name: 'name',
-      event_starts_at: '2017-03-04 13:00',
-      event_ends_at: '2017-03-04 17:00'
-    }
-
-    it('converts snake case to camel case', () => {
-      const subject = subjectClass({})
-      expect(subject.camelKeysOf(snakeKeysParams)).toEqual(camelKeysParams)
     })
   })
 })

--- a/front/__tests__/models/Base.spec.js
+++ b/front/__tests__/models/Base.spec.js
@@ -111,4 +111,25 @@ describe('Base', () => {
       expect(subject.formatDateWith('eventStartsAt').toString()).toBe('2017-03-02T09:00:00Z')
     })
   })
+
+  describe('toSnakeKeys', () => {
+    const camelKeysParams = {
+      errors: [],
+      name: 'name',
+      eventStartsAt: '2017-03-04 13:00',
+      eventEndsAt: '2017-03-04 17:00'
+    }
+
+    const snakeKeysParams = {
+      errors: [],
+      name: 'name',
+      event_starts_at: '2017-03-04 13:00',
+      event_ends_at: '2017-03-04 17:00'
+    }
+
+    it('returns params with snake case keys', () => {
+      const subject = subjectClass(camelKeysParams)
+      expect(subject.toSnakeKeys()).toEqual(snakeKeysParams)
+    })
+  })
 })

--- a/front/__tests__/utils/ConvertCase.spec.js
+++ b/front/__tests__/utils/ConvertCase.spec.js
@@ -1,0 +1,27 @@
+import ConvertCase from '../../client/utils/ConvertCase'
+
+describe('ConvertCase', () => {
+  const camelKeysParams = {
+    name: 'name',
+    eventStartsAt: '2017-03-04 13:00',
+    eventEndsAt: '2017-03-04 17:00'
+  }
+
+  const snakeKeysParams = {
+    name: 'name',
+    event_starts_at: '2017-03-04 13:00',
+    event_ends_at: '2017-03-04 17:00'
+  }
+
+  describe('camelKeysOf', () => {
+    it('converts snake case to camel case', () => {
+      expect(ConvertCase.camelKeysOf(snakeKeysParams)).toEqual(camelKeysParams)
+    })
+  })
+
+  describe('snakeKeysOf', () => {
+    it('converts snake case to camel case', () => {
+      expect(ConvertCase.snakeKeysOf(camelKeysParams)).toEqual(snakeKeysParams)
+    })
+  })
+})

--- a/front/client/models/Base.js
+++ b/front/client/models/Base.js
@@ -1,5 +1,6 @@
 import { Record as originRecord } from 'immutable'
 import moment from 'moment'
+import _ from 'lodash' 
 
 export default (args = {}) => {
   const base = originRecord({errors: [], ...args})
@@ -25,6 +26,14 @@ export default (args = {}) => {
   
     formatDateWith(attribute) {
       return this.makeDateWith(attribute) ? moment(this.makeDateWith(attribute)).format() : null
+    }
+
+    convertKeys(dict, converter){
+      return _.mapKeys(dict, (v, k) => converter(k))
+    }
+
+    camelKeysOf(dict){
+      return this.convertKeys(dict, _.camelCase)
     }
   }
 }

--- a/front/client/models/Base.js
+++ b/front/client/models/Base.js
@@ -1,6 +1,6 @@
 import { Record as originRecord } from 'immutable'
 import moment from 'moment'
-import _ from 'lodash' 
+import ConvertCase from '../utils/ConvertCase'
 
 export default (args = {}) => {
   const base = originRecord({errors: [], ...args})
@@ -28,12 +28,8 @@ export default (args = {}) => {
       return this.makeDateWith(attribute) ? moment(this.makeDateWith(attribute)).format() : null
     }
 
-    convertKeys(dict, converter){
-      return _.mapKeys(dict, (v, k) => converter(k))
-    }
-
-    camelKeysOf(dict){
-      return this.convertKeys(dict, _.camelCase)
+    convertKeysToSnake(){
+      return ConvertCase.snakeKeysOf(this)
     }
   }
 }

--- a/front/client/models/Base.js
+++ b/front/client/models/Base.js
@@ -28,8 +28,8 @@ export default (args = {}) => {
       return this.makeDateWith(attribute) ? moment(this.makeDateWith(attribute)).format() : null
     }
 
-    convertKeysToSnake(){
-      return ConvertCase.snakeKeysOf(this)
+    toSnakeKeys(){
+      return ConvertCase.snakeKeysOf(this.toJSON())
     }
   }
 }

--- a/front/client/reducers/Community.js
+++ b/front/client/reducers/Community.js
@@ -6,11 +6,9 @@ export const communityInitialState = new Community()
 export const communityReducerMap = {
   CREATE_COMMUNITY: {
     next: (state, action) => {
-      return new Community({
-        id:           action.payload.id,
-        name:         action.payload.name,
-        description:  action.payload.description
-      })
+      return new Community(
+        (new Community).camelKeysOf(action.payload)
+      )
     },
     throw: (state, action) => {
       return new Community({

--- a/front/client/reducers/Community.js
+++ b/front/client/reducers/Community.js
@@ -1,14 +1,13 @@
 import { handleActions }  from 'redux-actions'
 import Community          from '../models/Community'
+import ConvertCase          from '../utils/ConvertCase'
 
 export const communityInitialState = new Community()
 
 export const communityReducerMap = {
   CREATE_COMMUNITY: {
     next: (state, action) => {
-      return new Community(
-        (new Community).camelKeysOf(action.payload)
-      )
+      return new Community(ConvertCase.camelKeysOf(action.payload))
     },
     throw: (state, action) => {
       return new Community({

--- a/front/client/reducers/CommunityList.js
+++ b/front/client/reducers/CommunityList.js
@@ -11,7 +11,7 @@ export const communityListReducerMap = {
       action.payload.map((item) => {
         return communityReducerMap.CREATE_COMMUNITY.next(
           null,
-          {payload: {id: item.id, name: item.name, description: item.description}}
+          {payload: item}
         )
       })
     )

--- a/front/client/reducers/Event.js
+++ b/front/client/reducers/Event.js
@@ -7,15 +7,9 @@ export const eventInitialState = new Event()
 export const eventReducerMap = {
   CREATE_EVENT: {
     next: (state, action) => {
-      const event = new Event({
-        id:             action.payload.id,
-        name:           action.payload.name,
-        description:    action.payload.description,
-        communityId:    action.payload.community_id,
-        eventStartsAt:  action.payload.event_starts_at,
-        eventEndsAt:    action.payload.event_ends_at,
-        address:        action.payload.address
-      })
+      const event = new Event(
+          (new Event).camelKeysOf(action.payload)
+        )
       return event.setTickets(
         action.payload.tickets ? action.payload.tickets.map((item) => {
           return ticketReducerMap.CREATE_TICKET.next(

--- a/front/client/reducers/Event.js
+++ b/front/client/reducers/Event.js
@@ -1,15 +1,14 @@
 import { handleActions }    from 'redux-actions'
 import Event                from '../models/Event'
 import { ticketReducerMap } from './Ticket'
+import ConvertCase          from '../utils/ConvertCase'
 
 export const eventInitialState = new Event()
 
 export const eventReducerMap = {
   CREATE_EVENT: {
     next: (state, action) => {
-      const event = new Event(
-          (new Event).camelKeysOf(action.payload)
-        )
+      const event = new Event(ConvertCase.camelKeysOf(action.payload))
       return event.setTickets(
         action.payload.tickets ? action.payload.tickets.map((item) => {
           return ticketReducerMap.CREATE_TICKET.next(

--- a/front/client/reducers/Ticket.js
+++ b/front/client/reducers/Ticket.js
@@ -6,15 +6,9 @@ export const ticketInitialState = new Ticket()
 export const ticketReducerMap = {
   CREATE_TICKET: {
     next: (state, action) => {
-      return new Ticket({
-        id:           action.payload.id,
-        name:         action.payload.name,
-        cost:         action.payload.cost,
-        quantity:     action.payload.quantity,
-        eventId:      action.payload.event_id,
-        saleStartsAt: action.payload.sale_starts_at,
-        saleEndsAt:   action.payload.sale_ends_at
-      })
+      return new Ticket(
+        (new Ticket).camelKeysOf(action.payload)
+      )
     },
     throw: (state, action) => {
       return new Ticket({

--- a/front/client/reducers/Ticket.js
+++ b/front/client/reducers/Ticket.js
@@ -1,14 +1,13 @@
 import { handleActions }  from 'redux-actions'
 import Ticket             from '../models/Ticket'
+import ConvertCase        from '../utils/ConvertCase'
 
 export const ticketInitialState = new Ticket()
 
 export const ticketReducerMap = {
   CREATE_TICKET: {
     next: (state, action) => {
-      return new Ticket(
-        (new Ticket).camelKeysOf(action.payload)
-      )
+      return new Ticket(ConvertCase.camelKeysOf(action.payload))
     },
     throw: (state, action) => {
       return new Ticket({

--- a/front/client/utils/ConvertCase.js
+++ b/front/client/utils/ConvertCase.js
@@ -1,16 +1,16 @@
 import _ from 'lodash' 
 
-const ConvertCase = {
-  convertKeys(dict, converter){
-    return _.mapKeys(dict, (v, k) => converter(k))
-  },
+const convertKeys  = (dict, converter) => {
+  return _.mapKeys(dict, (v, k) => converter(k))
+}
 
+const ConvertCase = {
   camelKeysOf(dict){
-    return this.convertKeys(dict, _.camelCase)
+    return convertKeys(dict, _.camelCase)
   },
 
   snakeKeysOf(dict){
-    return this.convertKeys(dict, _.snakeCase)
+    return convertKeys(dict, _.snakeCase)
   }
 }
 

--- a/front/client/utils/ConvertCase.js
+++ b/front/client/utils/ConvertCase.js
@@ -1,0 +1,17 @@
+import _ from 'lodash' 
+
+const ConvertCase = {
+  convertKeys(dict, converter){
+    return _.mapKeys(dict, (v, k) => converter(k))
+  },
+
+  camelKeysOf(dict){
+    return this.convertKeys(dict, _.camelCase)
+  },
+
+  snakeKeysOf(dict){
+    return this.convertKeys(dict, _.snakeCase)
+  }
+}
+
+export default ConvertCase


### PR DESCRIPTION
### Overview:概要
同一のパラメータ名でもjavascriptではcamel caseで、Rubyではsnake caseで表現する。このためフロントエンドのサーバからのデータ取得時にパラメータ名の変換を行う関数を追加する。

### Technical changes:技術的変更点
- すでにインストールしているlodashパッケージのmapKeys()、camelCase()、snakeCase()を使用して、パラメータ名をsnake caseとcamel caseと相互に変換する関数をutilsディレクトリに作成する
- Baseモデルに上記の変換関数を利用する関数を追加して、 Reducerのstore更新処理で利用する

### Impact point:変更に関する影響箇所
none

### Change of UserInterface:UIの変更
none

### Others
- テストでも同様に変換が必要な箇所があるため、このPRが完了した後でリファクタリングしたいと思います。