### PR TITLE
Add endpoint 'POST /tickets/:ticket_id/subscription'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,9 @@ group :test do
 
   # database cleaner
   gem 'database_rewinder'
+
+  # for request spec
+  gem 'rspec-request_describer'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,8 @@ GEM
       rspec-expectations (~> 3.5.0)
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
+    rspec-request_describer (0.2.1)
+      actionpack (>= 5.0.0)
     rspec-support (3.5.0)
     rubocop (0.47.1)
       parser (>= 2.3.3.1, < 3.0)
@@ -325,6 +327,7 @@ DEPENDENCIES
   rails-controller-testing
   rspec-json_expectations
   rspec-rails (~> 3.5)
+  rspec-request_describer
   rubocop
   settingslogic
   shoulda-matchers

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,0 +1,20 @@
+class SubscriptionsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_ticket
+
+  def create
+    purchase_ticket = current_user.purchases @ticket
+
+    if purchase_ticket.save
+      render json: purchase_ticket, status: :created
+    else
+      render_error purchase_ticket, :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_ticket
+    @ticket = Ticket.find(params[:ticket_id])
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,8 @@ class User < ActiveRecord::Base
 
   has_many :ticket_subscriptions
   has_many :tickets, through: :ticket_subscriptions
+
+  def purchases(ticket)
+    ticket_subscriptions.build(ticket: ticket, quantity: 1)
+  end
 end

--- a/app/serializers/ticket_subscription_serializer.rb
+++ b/app/serializers/ticket_subscription_serializer.rb
@@ -1,0 +1,4 @@
+class TicketSubscriptionSerializer < ActiveModel::Serializer
+  attributes :id, :quantity
+  belongs_to :ticket
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'auth'
   resources :communities, shallow: true, :defaults => { :format => 'json' } do
     resources :events do
-      resources :tickets
+      resources :tickets do
+        resources :subscriptions, only: :create
+      end
     end
   end
 end

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe SubscriptionsController, type: :controller do
+  it { is_expected.to use_before_action(:authenticate_user!) }
+end

--- a/spec/factories/ticket_subscriptions.rb
+++ b/spec/factories/ticket_subscriptions.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :ticket_subscription do
+    quantity 1
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,7 +1,8 @@
 FactoryGirl.define do
   factory :user do
-    email 'test@example.com'
-    password 'password'
-    password_confirmation 'password'
+    email { Faker::Internet.email }
+    password "password"
+    password_confirmation "password"
+    confirmed_at Date.today
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,6 +74,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include RSpec::RequestDescriber, type: :request
+  config.include SerializerHelper, type: :serializer
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe "POST /tickets/:ticket_id/subscriptions", type: :request do
+  let(:user) { create(:user) }
+  let(:ticket) { build_stubbed(:ticket) }
+  let(:ticket_id) { ticket.id }
+  let(:headers) { user.create_new_auth_token }
+  let(:current_user) { user }
+  let(:ticket_subscription) { build_stubbed(:ticket_subscription, ticket: ticket) }
+
+  before do
+    allow(Ticket).to receive(:find).and_return(ticket)
+    allow_any_instance_of(DeviseTokenAuth::Controllers::Helpers).to receive(:current_user).and_return(user)
+    allow(user).to receive(:purchases).and_return(ticket_subscription)
+  end
+
+  context 'success' do
+    before do
+      allow(ticket_subscription).to receive(:save).and_return(true)
+    end
+
+    example do
+      subject
+      expect(response).to have_http_status(:created)
+    end
+  end
+
+  context 'failure' do
+    before do
+      allow(ticket_subscription).to receive(:save).and_return(false)
+    end
+
+    example do
+      subject
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/serializers/ticket_subscription_serializer_spec.rb
+++ b/spec/serializers/ticket_subscription_serializer_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe TicketSubscriptionSerializer, type: :serializer do
+  describe 'data' do
+    let(:ticket) { build_stubbed(:ticket) }
+    let(:ticket_subscription) { build_stubbed(:ticket_subscription, ticket: ticket) }
+
+    subject { serialize_with_json_api(ticket_subscription) }
+
+    it do
+      is_expected.to include_json(
+        data: {
+          id: ticket_subscription.id.to_s,
+          attributes: {
+            quantity: ticket_subscription.quantity
+          },
+          relationships: {
+            ticket: {
+              data: {
+                id: ticket.id.to_s
+              }
+            }
+          }
+        }
+      )
+    end
+  end
+end

--- a/spec/support/serializer_helper.rb
+++ b/spec/support/serializer_helper.rb
@@ -1,0 +1,11 @@
+module SerializerHelper
+  def serialize(resource, opts={})
+    serializer = described_class.new(resource)
+    ActiveModelSerializers::Adapter.create(serializer, opts).to_json
+  end
+
+  def serialize_with_json_api(resource, opts={})
+    serialize_opts = {adapter: :json_api}.reverse_merge(opts)
+    serialize(resource, serialize_opts)
+  end
+end


### PR DESCRIPTION
### Overview:概要
#168

### Technical changes:技術的変更点
* add authentication
* add endpoint `POST /tickets/:ticket_id/subscription`
* add spec

### API
```
POST /tickets/:ticket_id/subscription

# Response
status 201

{"data"=>
  {"id"=>"1006",
   "type"=>"ticket-subscriptions",
   "attributes"=>
    {"quantity"=>1},
   "relationships"=>{"ticket"=>{"data"=>{"id"=>"1005", "type"=>"tickets"}}}
  }
}
```

### TODO
- [x] Add TicketSubscription Serializer
- [x] Add Serializer spec
- [x] Add Request spec