### PR TITLE
Create owner data when creating community

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -10,8 +10,7 @@ class CommunitiesController < ApplicationController
 
   # paramsハッシュデータをPOSTする場合
   def create
-    @community = Community.new(community_params)
-    @community.owners.build(user: current_user)
+    @community = Community.new_with_owners(community_params.to_h.merge(owners: {user: current_user}))
     if @community.save
       # resource毎に使うシリアライザーを変えたいときはeach_serializerで指定する
       render json: @community, status: :created, location: @community

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -11,6 +11,7 @@ class CommunitiesController < ApplicationController
   # paramsハッシュデータをPOSTする場合
   def create
     @community = Community.new(community_params)
+    @community.owners.build(user: current_user)
     if @community.save
       # resource毎に使うシリアライザーを変えたいときはeach_serializerで指定する
       render json: @community, status: :created, location: @community

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,4 +1,5 @@
 class Community < ApplicationRecord
+  has_many :owners
   has_many :events
   has_many :tickets, through: :events
 

--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -5,5 +5,10 @@ class Community < ApplicationRecord
 
   validates :name, presence: true
   validates :description, presence: true
-  
+
+  def self.new_with_owners(attributes = nil)
+    self.new(attributes&.except(:owners)) do |c|
+      c.owners.build(attributes.try!(:[], :owners))
+    end
+  end
 end

--- a/spec/models/community_spec.rb
+++ b/spec/models/community_spec.rb
@@ -10,4 +10,23 @@ RSpec.describe Community, type: :model do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:description) }
   end
+
+  describe '::new_with_owners' do
+    let(:subject) { Community.new_with_owners(new_params).owners }
+
+    context 'not exist owners attributes' do
+      let(:new_params) { nil }
+      it { is_expected.to be_present }
+      example 'user_id of owners is nil' do
+        expect(subject.first.user_id).to be_nil
+      end
+    end
+    context 'exist owners attributes' do
+      let(:new_params) { {owners: {user_id: 1}} }
+      it { is_expected.to be_present }
+      example 'user_id of owners is 1' do
+        expect(subject.first.user_id).to eq 1
+      end
+    end
+  end
 end

--- a/spec/requests/communities_spec.rb
+++ b/spec/requests/communities_spec.rb
@@ -48,9 +48,8 @@ RSpec.describe 'Communities(コミュニティーAPI)', type: :request do
       end
 
       example 'コミュニティーが作成されること' do
-        expect do
-          post communities_path, params: community_params, headers: auth_headers
-        end.to change(Community, :count).by(1)
+        expect(Community.count).to eq 1
+        expect(Owner.count).to eq 1
       end
 
       example 'JSONに含まれるキーが適切であること' do


### PR DESCRIPTION
### Overview:概要
https://github.com/shinosakarb/tebukuro/issues/125

### Technical changes:技術的変更点
なし

### Impact point:変更に関する影響箇所
- community作成時にownerを同時に作成するように変更。
