### PR TITLE
Modify refer community by current user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'devise_token_auth'
 gem 'omniauth-twitter'
 gem 'omniauth-facebook'
 gem 'omniauth-github'
+gem 'pundit'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,8 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     puma (3.8.2)
+    pundit (1.1.0)
+      activesupport (>= 3.0.0)
     rack (2.0.1)
     rack-cors (0.4.1)
     rack-protection (1.5.3)
@@ -323,6 +325,7 @@ DEPENDENCIES
   pry-rescue
   pry-stack_explorer
   puma (~> 3.7)
+  pundit
   rack-cors
   rails (~> 5.1.0.rc1)
   rails-controller-testing

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,18 +1,30 @@
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
+  include Pundit
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
+  rescue_from Pundit::NotAuthorizedError,   with: :not_allowed
+
+  def self.inherited(subclass)
+    authorize_name = subclass.controller_name.singularize
+    define_method("authorize_#{authorize_name}") { authorize instance_variable_get("@#{authorize_name}") }
+  end
 
   protected
 
   def not_found(exception)
-    model = build_not_found_model(exception.model)
+    model = build_error_model(exception.model, :id, 'Not found')
     render_error(model, :not_found)
   end
 
-  def build_not_found_model(model_name)
+  def not_allowed(exception)
+    model = build_error_model(exception.record.class.to_s, :id, 'Not allowed')
+    render_error(model, :forbidden)
+  end
+
+  def build_error_model(model_name, attribute, message)
     model = model_name.classify.constantize.new
-    model.errors.add(:id, 'Not found')
+    model.errors.add(attribute, message)
     model
   end
 

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,8 +1,8 @@
 class CommunitiesController < ApplicationController
 
   before_action :authenticate_user!, only: [:create, :update, :destroy]
-  before_action :set_community, only: [:show]
-  before_action :set_community_by_current_user, only: [:update, :destroy]
+  before_action :set_community, only: [:show, :update, :destroy]
+  before_action :authorize_community, only: [:update, :destroy]
 
   def index
     @communities = Community.all
@@ -46,9 +46,4 @@ class CommunitiesController < ApplicationController
   def set_community
     @community = Community.find(params[:id])
   end
-
-  def set_community_by_current_user
-    @community = Owner.find_by!(user: current_user, community_id: params[:id]).community
-  end
-
 end

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,21 +1,20 @@
 class CommunitiesController < ApplicationController
 
-  before_action :authenticate_user!, only: [:create]
-  before_action :set_community, only: [:show, :update, :destroy]
+  before_action :authenticate_user!, only: [:create, :update, :destroy]
+  before_action :set_community, only: [:show]
+  before_action :set_community_by_current_user, only: [:update, :destroy]
 
   def index
     @communities = Community.all
     render json: @communities
   end
 
-  # paramsハッシュデータをPOSTする場合
   def create
     @community = Community.new_with_owners(community_params.to_h.merge(owners: {user: current_user}))
     if @community.save
-      # resource毎に使うシリアライザーを変えたいときはeach_serializerで指定する
       render json: @community, status: :created, location: @community
     else
-      render json: @community.errors, status: :unprocessable_entity
+      render_error @community, :unprocessable_entity
     end
   end
 
@@ -27,7 +26,7 @@ class CommunitiesController < ApplicationController
     if @community.update(community_params)
       render json: @community
     else
-      render json: @community.errors, status: :unprocessable_entity
+      render_error @community, :unprocessable_entity
     end
   end
 
@@ -35,7 +34,7 @@ class CommunitiesController < ApplicationController
     if @community.destroy
       render json: @community
     else
-      render json: @community.errors, status: :unprocessable_entity
+      render_error @community, :unprocessable_entity
     end
   end
 
@@ -46,6 +45,10 @@ class CommunitiesController < ApplicationController
 
   def set_community
     @community = Community.find(params[:id])
+  end
+
+  def set_community_by_current_user
+    @community = Owner.find_by!(user: current_user, community_id: params[:id]).community
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,8 @@ class User < ActiveRecord::Base
   def purchases(ticket)
     ticket_subscriptions.build(ticket: ticket, quantity: 1)
   end
+
+  def owner?(community)
+    community.owners.exists?(user: self)
+  end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    scope.where(:id => record.id).exists?
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  def scope
+    Pundit.policy_scope!(user, record.class)
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/community_policy.rb
+++ b/app/policies/community_policy.rb
@@ -1,14 +1,9 @@
 class CommunityPolicy < ApplicationPolicy
   def update?
-    owner?
+    user.owner?(record)
   end
 
   def destroy?
-    owner?
-  end
-
-  private
-  def owner?
-    record.owners.exists?(user: user)
+    user.owner?(record)
   end
 end

--- a/app/policies/community_policy.rb
+++ b/app/policies/community_policy.rb
@@ -1,0 +1,14 @@
+class CommunityPolicy < ApplicationPolicy
+  def update?
+    owner?
+  end
+
+  def destroy?
+    owner?
+  end
+
+  private
+  def owner?
+    record.owners.exists?(user: user)
+  end
+end

--- a/spec/controllers/communities_controller_spec.rb
+++ b/spec/controllers/communities_controller_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe CommunitiesController, type: :controller do
   it { should use_before_action(:authenticate_user!) }
+  it { should use_before_action(:authorize_community) }
 end

--- a/spec/factories/owners.rb
+++ b/spec/factories/owners.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :owner do
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,4 +5,31 @@ describe User, type: :model do
     it { is_expected.to have_many(:ticket_subscriptions) }
     it { is_expected.to have_many(:tickets).through(:ticket_subscriptions) }
   end
+
+  describe '#owner?' do
+    let(:user) { create(:user) }
+    subject{ user.owner? community }
+
+    context 'other community' do
+      let(:community) do
+        community = build(:community)
+        community.owners.build(user: create(:user))
+        community.save
+        community
+      end
+
+      it { is_expected.to eq false }
+    end
+
+    context "user's community" do
+      let(:community) do
+        community = build(:community)
+        community.owners.build(user: user)
+        community.save
+        community
+      end
+
+      it { is_expected.to eq true }
+    end
+  end
 end

--- a/spec/policies/community_policy_spec.rb
+++ b/spec/policies/community_policy_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe CommunityPolicy do
+  subject { described_class }
+
+  permissions :update?, :destroy? do
+    let(:user) { create(:user) }
+    let(:user_community) do
+      community = build(:community)
+      community.owners.build(user: user)
+      community.save
+      community
+    end
+    let(:other_community) do
+      community = build(:community)
+      community.owners.build(user: create(:user))
+      community.save
+      community
+    end
+
+    it { expect(subject).to permit(user, user_community) }
+    it { expect(subject).not_to permit(user, other_community) }
+  end
+end

--- a/spec/policies/community_policy_spec.rb
+++ b/spec/policies/community_policy_spec.rb
@@ -4,21 +4,17 @@ RSpec.describe CommunityPolicy do
   subject { described_class }
 
   permissions :update?, :destroy? do
-    let(:user) { create(:user) }
-    let(:user_community) do
-      community = build(:community)
-      community.owners.build(user: user)
-      community.save
-      community
-    end
-    let(:other_community) do
-      community = build(:community)
-      community.owners.build(user: create(:user))
-      community.save
-      community
+    let(:user) { build_stubbed(:user) }
+    let(:community) { build_stubbed(:community) }
+
+    context "user's community" do
+      before { allow(user).to receive(:owner?).and_return(true) }
+      it { expect(subject).to permit(user, community) }
     end
 
-    it { expect(subject).to permit(user, user_community) }
-    it { expect(subject).not_to permit(user, other_community) }
+    context 'other community' do
+      before { allow(user).to receive(:owner?).and_return(false) }
+      it { expect(subject).not_to permit(user, community) }
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require 'shoulda/matchers'
+require "pundit/rspec"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/requests/communities_spec.rb
+++ b/spec/requests/communities_spec.rb
@@ -138,17 +138,13 @@ RSpec.describe 'Communities(コミュニティーAPI)', type: :request do
   describe 'PATCH /communities/:id' do
     let(:user) { build_stubbed(:user) }
     let(:community) { build_stubbed(:community) }
-    let(:owner) do
-      owner = build_stubbed(:owner)
-      owner.community = community
-      owner
-    end
     let(:id) { community.id }
     let(:params) { {community: attributes_for(:community, name: 'hogehoge')} }
 
     before do
       sign_in_with(user)
-      allow(Owner).to receive(:find_by!).and_return(owner)
+      allow(Community).to receive(:find).and_return(community)
+      allow_any_instance_of(CommunityPolicy).to receive(:update?).and_return(true)
     end
 
     context 'success' do
@@ -163,26 +159,13 @@ RSpec.describe 'Communities(コミュニティーAPI)', type: :request do
     end
 
     context 'failure' do
-      context 'community is not exists' do
-        before do
-          allow(Owner).to receive(:find_by!).and_raise(ActiveRecord::RecordNotFound.new(nil, 'owners'))
-        end
-
-        example do
-          subject
-          expect(response).to have_http_status(:not_found)
-        end
+      before do
+        allow(community).to receive(:update).and_return(false)
       end
 
-      context 'update fails' do
-        before do
-          allow(community).to receive(:update).and_return(false)
-        end
-
-        example do
-          subject
-          expect(response).to have_http_status(:unprocessable_entity)
-        end
+      example do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 
@@ -192,16 +175,12 @@ RSpec.describe 'Communities(コミュニティーAPI)', type: :request do
   describe 'DELETE /communities/:id' do
     let(:user) { build_stubbed(:user) }
     let(:community) { build_stubbed(:community) }
-    let(:owner) do
-      owner = build_stubbed(:owner)
-      owner.community = community
-      owner
-    end
     let(:id) { community.id }
 
     before do
       sign_in_with(user)
-      allow(Owner).to receive(:find_by!).and_return(owner)
+      allow(Community).to receive(:find).and_return(community)
+      allow_any_instance_of(CommunityPolicy).to receive(:destroy?).and_return(true)
     end
 
     context 'success' do
@@ -216,26 +195,13 @@ RSpec.describe 'Communities(コミュニティーAPI)', type: :request do
     end
 
     context 'failure' do
-      context 'community is not exists' do
-        before do
-          allow(Owner).to receive(:find_by!).and_raise(ActiveRecord::RecordNotFound.new(nil, 'owners'))
-        end
-
-        example do
-          subject
-          expect(response).to have_http_status(:not_found)
-        end
+      before do
+        allow(community).to receive(:destroy).and_return(false)
       end
 
-      context 'destroy fails' do
-        before do
-          allow(community).to receive(:destroy).and_return(false)
-        end
-
-        example do
-          subject
-          expect(response).to have_http_status(:unprocessable_entity)
-        end
+      example do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end


### PR DESCRIPTION
### Overview:概要
https://github.com/shinosakarb/tebukuro/issues/125
- communityの修正および削除APIにて、ログインユーザがOwnerである場合にのみ修正（参照）できるよう修正
- エラー時のJSONフォーマットをjson apiに変更

### Technical changes:技術的変更点
`current_user`とidにてOwnerおよびCommunityを参照する。
ただし、showアクションについては従来通りにidのみで参照する。

### Impact point:変更に関する影響箇所
本PRをマージすることで、Communityに関するAPIの修正は完了するが、逆にフロント側が完全に動作しなくなる。
