### PR TITLE
Add user authorization to event

### DIFF
--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -1,0 +1,13 @@
+class EventPolicy < ApplicationPolicy
+  def create?
+    user.owner?(record.community)
+  end
+
+  def update?
+    user.owner?(record.community)
+  end
+
+  def destroy?
+    user.owner?(record.community)
+  end
+end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe EventsController, type: :controller do
+  it { should use_before_action(:authenticate_user!) }
+  it { should use_before_action(:authorize_event) }
+end

--- a/spec/policies/event_policy_spec.rb
+++ b/spec/policies/event_policy_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe EventPolicy do
+  subject { described_class }
+
+  permissions :create?, :update?, :destroy? do
+    let(:user) { build_stubbed(:user) }
+    let(:event) { build_stubbed(:event) }
+
+    context "user's event of community" do
+      before { allow(user).to receive(:owner?).and_return(true) }
+      it { expect(subject).to permit(user, event) }
+    end
+
+    context 'other event of community' do
+      before { allow(user).to receive(:owner?).and_return(false) }
+      it { expect(subject).not_to permit(user, event) }
+    end
+  end
+end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Events(イベントAPI)', type: :request do
-
+  let(:user) { build_stubbed(:user) }
   let(:community) { FactoryGirl.create(:community) }
 
   describe 'GET community_events_path (events#index)' do
@@ -45,95 +45,40 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
   end
 
 
-  describe 'POST community_events_path (events#create)' do
+  describe 'POST /communities/:community_id/events' do
+    let(:community_id) {community.id}
+    let(:params) { {event: attributes_for(:event)} }
+    let(:event) { FactoryGirl.build_stubbed(:event, community: community) }
 
-    context '正常系' do
-
-      # event_paramsのデータ型は全てstring型になるため、dummy_eventを用意しておく
-      let(:dummy_event) { FactoryGirl.attributes_for(:event)}
-      let(:event_params) { {event: dummy_event} }
-      let(:event_json_parse){JSON.parse(dummy_event.to_json).except('id','community_id')}
-
-      before do
-        post community_events_path(community), params: event_params
-      end
-
-      subject do
-        JSON.parse(response.body)
-      end
-
-      example 'ステータス201を返されること' do
-        expect(response).to have_http_status(:created)
-      end
-
-      example 'イベントが作成されること' do
-        expect do
-          post community_events_path(community), params: event_params
-        end.to change(Event, :count).by(1)
-      end
-
-      example 'JSONに含まれるkeyが適切であること' do
-        expect(subject.except('id', 'community_id')).to include_json(event_json_parse)
-      end
-
-      example 'JSONに含まれる情報が適切であること' do
-        expect(subject['community_id']).to eq community['id']
-        expect(subject.except('id', 'community_id')).to include_json(event_json_parse)
-      end
-
+    before do
+      sign_in_with(user)
+      allow(Community).to receive(:find).and_return(community)
+      allow(community).to receive_message_chain('events.build').and_return(event)
+      allow_any_instance_of(EventPolicy).to receive(:create?).and_return(true)
     end
 
-    context '異常系' do
-
-      context 'nameが未記入' do
-        let(:event_name_blank_params) { {event: FactoryGirl.attributes_for(:event, name: nil)} }
-        before do
-          post community_events_path(community), params: event_name_blank_params
-        end
-
-        subject do
-          JSON.parse(response.body)
-        end
-
-        example 'エラーが返ってくること' do
-          expect(subject).to be_has_key 'name'
-        end
+    context 'success' do
+      before do
+        allow(event).to receive(:save).and_return(true)
       end
 
-      context 'descriptionが未記入' do
-        let(:event_description_blank_params) { {event: FactoryGirl.attributes_for(:event, description: nil)} }
+      example do
+        subject
+        expect(response).to have_http_status(:created)
+      end
+    end
 
-        before do
-          post community_events_path(community), params: event_description_blank_params
-        end
-
-        subject do
-          JSON.parse(response.body)
-        end
-
-        example 'エラーが返ってくること' do
-          expect(subject).to be_has_key 'description'
-        end
+    context 'failure' do
+      before do
+        allow(event).to receive(:save).and_return(false)
       end
 
-      context 'name, descriptionが未記入' do
-        let(:event_blank_params) { {event: FactoryGirl.attributes_for(:event, name: nil, description: nil)} }
-        before do
-          post community_events_path(community), params: event_blank_params
-        end
-
-        subject do
-          JSON.parse(response.body)
-        end
-
-        example 'エラーが返ってくること' do
-          expect(subject).to be_has_key 'name'
-          expect(subject).to be_has_key 'description'
-        end
+      example do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end
-
 
   describe 'GET event_path (events#show)' do
 
@@ -184,156 +129,70 @@ RSpec.describe 'Events(イベントAPI)', type: :request do
   end
 
 
-  describe 'PATCH event_path (events#update)' do
-
-    let(:event) { FactoryGirl.create(:event, community: community) }
+  describe 'PATCH /events/:id' do
+    let(:event) { FactoryGirl.build_stubbed(:event, community: community) }
+    let(:id) { event.id }
+    let(:params) { {event: attributes_for(:event, name: 'hogehoge')} }
 
     before do
-      @name = event.name
-      @description = event.description
-      @address = event.address
+      sign_in_with(user)
+      allow(Event).to receive(:find).and_return(event)
+      allow_any_instance_of(EventPolicy).to receive(:update?).and_return(true)
     end
 
-    context '正常系' do
-
-      context '有効なパラメータ(name)の場合' do
-
-        before do
-          patch event_path(event), params: {event: attributes_for(:event, name: 'hogehoge')}
-        end
-
-        example 'ステータス200が返ってくること' do
-          expect(response.status).to eq 200
-        end
-
-        example 'イベントのnameが更新されること' do
-          event.reload
-          expect(event.name).to eq 'hogehoge'
-        end
-
+    context 'success' do
+      before do
+        allow(event).to receive(:update).and_return(true)
       end
 
-
-      context '有効なパラメータ(description)の場合' do
-
-        before do
-          patch event_path(event), params: {event: attributes_for(:event, description: 'hogehoge')}
-        end
-
-        example 'ステータス200が返ってくること' do
-          expect(response.status).to eq 200
-        end
-
-        example 'イベントのdescriptionが更新されること' do
-          event.reload
-          expect(event.description).to eq 'hogehoge'
-        end
-
+      example do
+        subject
+        expect(response).to have_http_status(:ok)
       end
-
-      context '有効なパラメータ(address)の場合' do
-
-        before do
-          patch event_path(event), params: {event: attributes_for(:event, address: 'hogehoge')}
-        end
-
-        example 'ステータス200が返ってくること' do
-          expect(response.status).to eq 200
-        end
-
-        example 'イベントのaddressが更新されること' do
-          event.reload
-          expect(event.address).to eq 'hogehoge'
-        end
-      end
-
     end
 
-    context '異常系' do
-
-      context '無効なパラメータ(name)の場合' do
-
-        before do
-          patch event_path(event), params: {event: attributes_for(:event, name: nil)}
-        end
-
-        example 'ステータス422が返ってくること' do
-          expect(response.status).to eq 422
-        end
-
-        example 'DBのイベントは更新されないこと' do
-          event.reload
-          expect(event.name).to eq @name
-        end
-
+    context 'failure' do
+      before do
+        allow(event).to receive(:update).and_return(false)
       end
 
-      context '無効なパラメータ(description)の場合' do
-
-        before do
-          patch event_path(event), params: {event: attributes_for(:event, description: nil)}
-        end
-
-        example 'ステータス422が返ってくること' do
-          expect(response.status).to eq 422
-        end
-
-        example 'イベントのdescriptionは更新されないこと' do
-          event.reload
-          expect(event.description).to eq @description
-        end
-
+      example do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
       end
-
-      context '要求されたイベントが存在しない場合' do
-
-        before do
-          patch event_path(community_id: community.id, id: 0), params: {event: attributes_for(:event, description: 'hogehoge')}
-        end
-
-        example 'リクエストはRecordNotFoundとなること' do
-          expect(response.status).to eq 404
-        end
-      end
-
     end
-
   end
 
 
-  describe 'DELETE event_path (events#destroy)' do
+  describe 'DELETE /events/:id' do
+    let(:event) { FactoryGirl.build_stubbed(:event, community: community) }
+    let(:id) { event.id }
 
-    context '正常系' do
-
-      let!(:event) { FactoryGirl.create(:event, community: community) }
-
-      subject do
-        delete event_path(event)
-      end
-
-      example 'ステータス200を返すこと' do
-        subject
-        expect(response.status).to eq 200
-      end
-
-      example 'DBから要求されたユーザーが削除されること' do
-        expect {subject}.to change(Event, :count).by(-1)
-      end
-
+    before do
+      sign_in_with(user)
+      allow(Event).to receive(:find).and_return(event)
+      allow_any_instance_of(EventPolicy).to receive(:destroy?).and_return(true)
     end
 
-    context '異常系' do
+    context 'success' do
+      before do
+        allow(event).to receive(:destroy).and_return(true)
+      end
 
-      context '要求されたイベントが存在しない場合' do
+      example do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+    end
 
-        before do
-          delete event_path(community_id: community.id, id: 0)
-        end
+    context 'failure' do
+      before do
+        allow(event).to receive(:destroy).and_return(false)
+      end
 
-        example 'ステータス404が返されること' do
-          expect(response.status).to eq 404
-        end
-
+      example do
+        subject
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end


### PR DESCRIPTION
### Overview:概要
https://github.com/shinosakarb/tebukuro/issues/125

### Technical changes:技術的変更点
- create/update/destoryに認可処理を追加
- create/update/destoryのエラー時のレンダリングをjson apiに変更
上記変更に伴いspecを修正

### Impact point:変更に関する影響箇所
create/update/destoryのアクション内以外の影響はなし（Client側も現在使用していない）
