### PR TITLE
Fix session cookie name from default( _session_id ) to _tebukuro

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,9 +36,7 @@ module Tebukuro
         controller_specs: false
     end
 
-    config.session_store :cookie_store, key: '_tebukuro'
-    config.middleware.use config.session_store, config.session_options
     config.middleware.use ActionDispatch::Cookies
-    config.middleware.use ActionDispatch::Session::CookieStore
+    config.middleware.use ActionDispatch::Session::CookieStore, key: '_tebukuro'
   end
 end


### PR DESCRIPTION
### Overview:概要
バックエンドから送信されるセッション管理用のcookieの名前が'_tebukuro'となるよう設定を変更する。

### Technical changes:技術的変更点
ActionDIspatch::Session::CookieStoreへのオプションとして、key: '_tebukuro'を与えてcookieの名前を指定する。

### Impact point:変更に関する影響箇所
セッション管理用cookieを取り扱う処理は現時点では無く影響なし

### Change of UserInterface:UIの変更
Docker環境でChromeブラウザの開発用コンソールから変更を確認した。

変更前：
![screenshot from 2017-04-05 20-48-16](https://cloud.githubusercontent.com/assets/10824691/24704591/46f7c326-1a43-11e7-942a-c1663ed36deb.png)

変更後：
![screenshot from 2017-04-05 20-46-39](https://cloud.githubusercontent.com/assets/10824691/24704598/4c9d6894-1a43-11e7-8435-fd0fe12da5c4.png)

