### PR TITLE
Call super method in self.inherited method of ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::API
   rescue_from Pundit::NotAuthorizedError,   with: :not_allowed
 
   def self.inherited(subclass)
+    super
     authorize_name = subclass.controller_name.singularize
     define_method("authorize_#{authorize_name}") { authorize instance_variable_get("@#{authorize_name}") }
   end


### PR DESCRIPTION
### Overview:概要
ブラウザから新規のCommunityをjsonでPOSTすると、Railsのwrap_parametersにより本来はパラメータが"community" =>  { "name" =>  ...}とラップされるが、現在は"application" => { "name" =>  ...}となっている。

Railsの出力画面：
![screenshot from 2017-04-07 14-03-21](https://cloud.githubusercontent.com/assets/10824691/24797889/465b2fb6-1bce-11e7-8c82-cca1d1bc3c91.png)

これは#191 のPRで、ApplicationControllerにself.inheritedメソッドを追加することで、親クラスであるActionControllerのメソッドがオーバーライド（上書き）されたためと考えられる。
（追加したself.inheritedメソッドを削除すると"community"でラップされる）
このため、self.inheritedメソッド内でsuperを呼び出すことで、ActionControllerのinheritedメソッドの内容を実行する。

### Technical changes:技術的変更点
none

### Impact point:変更に関する影響箇所
現在、"application" => { "name" =>  ...}となっているPOSTのパラメータが本来のcommunity(コントローラ名)となる。

### Change of UserInterface:UIの変更
変更後のRailsの出力画面：
![screenshot from 2017-04-07 14-04-00](https://cloud.githubusercontent.com/assets/10824691/24798284/165e3568-1bd0-11e7-8b3e-b4baa6f90d60.png)

### Others
- 上記の画面では動作確認として、devise_auth_tokenの認証用ヘッダを追加して実行しています。(本PRにはヘッダの追加処理は含まれていません)
- ActionControllerのinheritedメソッドは[RailsのGithubページ](https://github.com/rails/rails/blob/a9f28600e901b11a9222e34bfae8642bfb753186/actionpack/lib/action_controller/metal/params_wrapper.rb#L215)でソースコードを確認しました