### PR TITLE
Add Participant Model

### DIFF
--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ParticipantsController < ApplicationController
+  # POST /participants
+  def create
+    @participant = Participant.new(participant_params)
+
+    if @participant.save
+      render json: @participant, status: :created, location: @participant
+    else
+      render json: @participant.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  # Only allow a trusted parameter "white list" through.
+  def participant_params
+    params.require(:participant).permit(:name, :event_id)
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,7 @@
 class Event < ApplicationRecord
   belongs_to :community
   has_many :tickets
+  has_many :participants
 
   validates :name, presence: true
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1,0 +1,5 @@
+class Participant < ApplicationRecord
+  belongs_to :event
+
+  validates :name, presence: true
+end

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -1,8 +1,7 @@
 class EventSerializer < ActiveModel::Serializer
-  attributes :id, :name, :description, :community_id,
-             :event_starts_at, :event_ends_at, :address
+  attributes :id, :name, :description
 
-  has_many :tickets
+  has_many :participants
 
   # TODO: communitiesモデルが作成されたら、GETのURLをattributesに加えます。
 end

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -1,0 +1,4 @@
+class ParticipantSerializer < ActiveModel::Serializer
+  attributes :id, :event_id, :name
+  has_one :event
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :events
+  resources :events do
+    resources :participants, only: :create
+  end
 
   namespace :subscription do
     resources :tickets, only: :destroy

--- a/db/migrate/20171124045334_create_participants.rb
+++ b/db/migrate/20171124045334_create_participants.rb
@@ -1,0 +1,10 @@
+class CreateParticipants < ActiveRecord::Migration[5.1]
+  def change
+    create_table :participants do |t|
+      t.string :name, null: false
+      t.references :event, foreign_key: true, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170321233415) do
+ActiveRecord::Schema.define(version: 20171124045334) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,14 @@ ActiveRecord::Schema.define(version: 20170321233415) do
     t.datetime "updated_at", null: false
     t.index ["community_id"], name: "index_owners_on_community_id"
     t.index ["user_id"], name: "index_owners_on_user_id"
+  end
+
+  create_table "participants", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "event_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_participants_on_event_id"
   end
 
   create_table "ticket_subscriptions", force: :cascade do |t|
@@ -96,6 +104,7 @@ ActiveRecord::Schema.define(version: 20170321233415) do
 
   add_foreign_key "owners", "communities"
   add_foreign_key "owners", "users"
+  add_foreign_key "participants", "events"
   add_foreign_key "ticket_subscriptions", "tickets"
   add_foreign_key "ticket_subscriptions", "users"
   add_foreign_key "tickets", "events"

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Participant, type: :model do
+
+  describe 'association' do
+    it { is_expected.to belong_to(:event) }
+  end
+
+  describe 'validation' do
+    it { is_expected.to validate_presence_of(:name) }
+  end
+
+end


### PR DESCRIPTION
### Overview:概要
イベント (Event) に紐づく参加者 (Participant) のモデルを追加する。
イベントについては既存のモデルを流用する。

### Technical changes:技術的変更点
Rails の Scafflod 機能で作成したものをベースとした。

#### 参加者の作成処理
- schema、model、controller、route、serializer を追加
- イベントに紐付けるため、schema で外部キー制約を設定
- インデックスは外部キーである event_id に対して設定

#### 参加者の一覧取得処理
- イベントのmodel および serializer に has_many で 参加者 を追加、イベントのデータ取得時にイベント参加者の配列も取得。下のようなイメージ：
````
event : {
id: 1,
name: "event1",
description: "This is the first event!"
participants: [
{ id: 1, event_id: 1, name: 'Jimi' },
{ id: 2, event_id: 1, name: 'Eddie' }
]
````

### Impact point:変更に関する影響箇所
本PR での serializer の変更により、旧tebukuro でイベントのデータに含まれていた
- 開催場所
- コミュニティID
- イベント開始日時
- イベント終了日時
- チケット

は現行ではフロントエンドで未使用なので削除するため、送信されなくなる。

### Change of UserInterface:UIの変更
バックエンドの変更なのでなし