### PR TITLE
Fix error handling in events_controller and remove redirect location in participants_controller

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -12,7 +12,7 @@ class EventsController < ApplicationController
     if @event.save
       render json: @event, status: :created, location: @event
     else
-      render_error @event, :unprocessable_entity
+      render json: @event.errors, status: :unprocessable_entity
     end
   end
 
@@ -24,7 +24,7 @@ class EventsController < ApplicationController
     if @event.update(event_params)
       render json: @event, include: 'tickets'
     else
-      render_error @event, :unprocessable_entity
+      render json: @event.errors, status: :unprocessable_entity
     end
   end
 
@@ -32,14 +32,14 @@ class EventsController < ApplicationController
     if @event.destroy
       render json: @event
     else
-      render_error @event, :unprocessable_entity
+      render json: @event.errors, status: :unprocessable_entity
     end
   end
 
   private
+
   def event_params
     params.require(:event).permit(:name, :description)
-                                  
   end
 
   def set_event
@@ -49,5 +49,4 @@ class EventsController < ApplicationController
   def build_event
     @event = Event.new(event_params)
   end
-
 end

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -6,7 +6,7 @@ class ParticipantsController < ApplicationController
     @participant = Participant.new(participant_params)
 
     if @participant.save
-      render json: @participant, status: :created, location: @participant
+      render json: @participant, status: :created
     else
       render json: @participant.errors, status: :unprocessable_entity
     end


### PR DESCRIPTION
### Overview:概要
以下２点の不具合が発生しているため、修正する
- イベントのコントローラでイベント登録の失敗時のエラーメッセージが送信されない
- 参加者のコントローラで参加登録の成功時にリダイレクト先にURLが存在せず500エラーとなる

### Technical changes:技術的変更点
前述の不具合を下記の通り修正する。

- イベントのコントローラ
エラー処理ではjson_api を使用していた時点でのコードが残っており、このコードがエラーメッセージを返していない（原因よくわかりません、、）。このため、エラー処理を scaffold で生成されるものと同じものに戻す。

- 参加者のコントローラ
参加登録 (create) の成功時にリダイレクト先として、登録した参加者のインスタンスの URL を指定しているが、ルーティングが存在せずエラーとなる。参加登録処理ではページの遷移は起こらないので、リダイレクト先の指定を削除する。

### Impact point:変更に関する影響箇所
フロントエンドでイベント作成の失敗時にエラーメッセージが表示されるようになる。

### Change of UserInterface:UIの変更
なし

本来なら２つの異なる修正なので PR を分けるべきでしたが、共に修正範囲が小規模のため１つにまとめました。