### PR TITLE
Add participants attribute to event controller

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -17,12 +17,12 @@ class EventsController < ApplicationController
   end
 
   def show
-    render json: @event, include: 'tickets'
+    render json: @event, include: 'participants'
   end
 
   def update
     if @event.update(event_params)
-      render json: @event, include: 'tickets'
+      render json: @event, include: 'participants'
     else
       render json: @event.errors, status: :unprocessable_entity
     end


### PR DESCRIPTION
### Overview:概要
Enabling event controller to return the event with its participants on show and update action.

### Technical changes:技術的変更点
- Append ` include: 'participants'` to `@event` in show and update action.
- Remove unnecessary `'tickets'` from `@event`

### Impact point:変更に関する影響箇所
Event data from back end includes an array of its participants as `participants`.

### Change of UserInterface:UIの変更
No changes.