### PR TITLE
Add quota to Event

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -39,7 +39,7 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:name, :description)
+    params.require(:event).permit(:name, :description, :quota)
   end
 
   def set_event

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,12 @@
 class Event < ApplicationRecord
-  has_many :tickets
   has_many :participants
+  has_many :tickets
 
   validates :name, presence: true
+  validates :quota,
+    presence: true,
+    numericality:
+    { greater_than_or_equal_to: 1,
+      less_than_or_equal_to: 1000,
+      allow_blank: true }
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
+
 class Event < ApplicationRecord
   has_many :participants
   has_many :tickets
 
   validates :name, presence: true
   validates :quota,
-    presence: true,
-    numericality:
-    { greater_than_or_equal_to: 1,
-      less_than_or_equal_to: 1000,
-      allow_blank: true }
+            presence: true,
+            numericality:
+            { greater_than_or_equal_to: 1,
+              less_than_or_equal_to: 1000 }
 end

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -1,5 +1,5 @@
 class EventSerializer < ActiveModel::Serializer
-  attributes :id, :name, :description
+  attributes :id, :name, :description, :quota
 
   has_many :participants
 

--- a/db/migrate/20171215005955_add_quota_column_to_event.rb
+++ b/db/migrate/20171215005955_add_quota_column_to_event.rb
@@ -1,0 +1,5 @@
+class AddQuotaColumnToEvent < ActiveRecord::Migration[5.1]
+  def change
+    add_column :events, :quota, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171206011458) do
+ActiveRecord::Schema.define(version: 20171215005955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20171206011458) do
     t.datetime "event_starts_at"
     t.datetime "event_ends_at"
     t.string "address"
+    t.integer "quota", null: false
     t.index ["community_id"], name: "index_events_on_community_id"
   end
 

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 require 'faker'
 require 'date'
 
 FactoryBot.define do
-
   # 例) Sat, 10 Feb 2007 15:30:45 EST -05:00
   # 必ずこの形式でないと、JSON.parse()で日付のフォーマットがISO8061に変換されなくなる。
-  factory_time = Time.zone.local(2015,12,15)
+  factory_time = Time.zone.local(2015, 12, 15)
 
   trait :partial_event_detail_information do
     event_starts_at factory_time
@@ -13,10 +14,8 @@ FactoryBot.define do
   end
 
   factory :event do
-    sequence(:name) { |n| "イベント #{n}"  }
-    description {generate :description}
-    address { ForgeryJa(:address).full_address }
-    partial_event_detail_information
+    sequence(:name) { |n| "イベント #{n}" }
+    description { generate :description }
+    quota Faker::Number.between(1, 1000)
   end
-
 end

--- a/spec/factories/participants.rb
+++ b/spec/factories/participants.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'faker'
+
+FactoryBot.define do
+  factory :participant do
+    sequence(:name) { |n| "参加者 #{n}" }
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -3,11 +3,18 @@ require "rails_helper"
 describe Event, type: :model do
   describe 'association' do
     it { is_expected.to have_many(:participants) }
-    it { is_expected.to have_many(:tickets) }
   end
 
   describe 'validation' do
-    it { is_expected.to validate_presence_of(:name) }
-  end
+    describe '#name' do
+      it { is_expected.to validate_presence_of(:name) }
+    end
 
+    describe '#quota' do
+      it { is_expected.to validate_numericality_of(:quota).
+           is_greater_than_or_equal_to(1).
+           is_less_than_or_equal_to(1000).
+           allow_nil }
+    end
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,4 +1,6 @@
-require "rails_helper"
+# frozen_string_literal: true
+
+require 'rails_helper'
 
 describe Event, type: :model do
   describe 'association' do
@@ -11,10 +13,11 @@ describe Event, type: :model do
     end
 
     describe '#quota' do
-      it { is_expected.to validate_numericality_of(:quota).
-           is_greater_than_or_equal_to(1).
-           is_less_than_or_equal_to(1000).
-           allow_nil }
+      it {
+        is_expected.to validate_numericality_of(:quota)
+          .is_greater_than_or_equal_to(1)
+          .is_less_than_or_equal_to(1000)
+      }
     end
   end
 end

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EventSerializer, type: :serializer do
+  let(:event) { build_stubbed(:event) }
+
+  describe 'data' do
+    before { event.participants.build(attributes_for(:participant)) }
+
+    subject { serialize(event) }
+
+    it do
+      is_expected.to include_json(
+        name: event.name,
+        description: event.description,
+        quota: event.quota,
+        participants: [{
+          event_id: event.participants[0].event_id,
+          name: event.participants[0].name
+        }]
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Overview:概要
イベントの定員を設定するため、Event テーブルに定員カラムを追加する

### Technical changes:技術的変更点
- Event テーブルに以下のカラムを追加
  - カラム： `quota` (integer, not null)
- Event モデルに以下のバリデーションを追加
  - 入力必須
  - １以上１０００以下の整数であること
（１０００という上限値は、故意に大量の参加登録等を行いシステムに負担をかける事を防止する目的で設定します）
- Event コントローラの `strong_parameters` で `quota` を許可
- Event シリアライザで ` quota`  フィールドを追加
- Event シリアライザのテストがなかったので、本PR で追加

### Impact point:変更に関する影響箇所
- イベント作成時に定員の設定が必須となる

### Change of UserInterface:UIの変更
なし
