### PR TITLE
 Add cancel feature of event registration

### DIFF
--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -1,12 +1,22 @@
 # frozen_string_literal: true
 
 class ParticipantsController < ApplicationController
+  before_action :set_participant, only: [:destroy]
+  before_action :build_participant, only: [:create]
+
   # POST /participants
   def create
-    @participant = Participant.new(participant_params)
-
     if @participant.save
       render json: @participant, status: :created
+    else
+      render json: @participant.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /participants
+  def destroy
+    if @participant.destroy
+      render json: @participant
     else
       render json: @participant.errors, status: :unprocessable_entity
     end
@@ -17,5 +27,13 @@ class ParticipantsController < ApplicationController
   # Only allow a trusted parameter "white list" through.
   def participant_params
     params.require(:participant).permit(:name, :event_id)
+  end
+
+  def set_participant
+    @participant = Participant.find(params[:id])
+  end
+
+  def build_participant
+    @participant = Participant.new(participant_params)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'auth'
-  resources :communities, shallow: true, :defaults => { :format => 'json' } do
+  resources :communities, shallow: true, defaults: { format: 'json' } do
     resources :events do
       resources :tickets do
         resources :subscriptions, only: :create
@@ -9,7 +11,7 @@ Rails.application.routes.draw do
   end
 
   resources :events do
-    resources :participants, only: :create
+    resources :participants, only: %i[create destroy]
   end
 
   namespace :subscription do


### PR DESCRIPTION
### Overview:概要
イベントへの参加登録をキャンセルできるよう、参加者(Participants) を削除する機能を追加する。

### Technical changes:技術的変更点
- Participant コントローラに destroy メソッドを追加して、メソッド内で対象となる Participant のレコードを削除
- `routes.rb` で participant のルーティングに `destroy` を許可して、参加登録キャンセルのエンドポイントを追加

### Impact point:変更に関する影響箇所
他の機能へのなし

### Change of UserInterface:UIの変更
UIの変更はなし
