### PR TITLE
[WIP] Add admitted attribute to participant data for waiting list feature

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,4 +10,14 @@ class Event < ApplicationRecord
             numericality:
             { greater_than_or_equal_to: 1,
               less_than_or_equal_to: 1000 }
+
+  def admitted_participant?(participant_id)
+    admitted_participants.include?(participant_id)
+  end
+
+  private
+
+  def admitted_participants
+    @admitted_participants ||= participant_ids.sort.take(quota)
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
-  has_many :participants
+  has_many :participants, ->{ order :id }
   has_many :tickets
 
   validates :name, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
-  has_many :participants, ->{ order :id }
+  has_many :participants
   has_many :tickets
 
   validates :name, presence: true
@@ -11,13 +11,13 @@ class Event < ApplicationRecord
             { greater_than_or_equal_to: 1,
               less_than_or_equal_to: 1000 }
 
-  def admitted_participant?(participant_id)
-    admitted_participants.include?(participant_id)
+  def admitted_participant_ids
+    @admitted_participant_ids ||= take_admitted_participant_ids
   end
 
   private
 
-  def admitted_participants
-    @admitted_participants ||= participant_ids.sort.take(quota)
+  def take_admitted_participant_ids
+    quota ? participant_ids.sort.take(quota) : []
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,13 +11,13 @@ class Event < ApplicationRecord
             { greater_than_or_equal_to: 1,
               less_than_or_equal_to: 1000 }
 
-  def admitted_participant_ids
-    @admitted_participant_ids ||= take_admitted_participant_ids
+  def waitlisted_participant_ids
+    @waitlisted_participant_ids ||= get_waitlisted_participant_ids
   end
 
   private
 
-  def take_admitted_participant_ids
-    quota ? participant_ids.sort.take(quota) : []
+  def get_waitlisted_participant_ids
+    quota ? participant_ids.sort.drop(quota) : []
   end
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -4,6 +4,6 @@ class Participant < ApplicationRecord
   validates :name, presence: true
 
   def admitted
-    event.participants.take(event.quota).include?(self)
+    event.admitted_participant?(id)
   end
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -2,4 +2,8 @@ class Participant < ApplicationRecord
   belongs_to :event
 
   validates :name, presence: true
+
+  def admitted
+    event.participants.take(event.quota).include?(self)
+  end
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 class Participant < ApplicationRecord
   belongs_to :event
 
   validates :name, presence: true
 
-  def admitted
-    event.admitted_participant_ids.include?(id)
+  def waitlisted?
+    event.waitlisted_participant_ids.include?(id)
   end
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -4,6 +4,6 @@ class Participant < ApplicationRecord
   validates :name, presence: true
 
   def admitted
-    event.admitted_participant?(id)
+    event.admitted_participant_ids.include?(id)
   end
 end

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -1,4 +1,4 @@
 class ParticipantSerializer < ActiveModel::Serializer
-  attributes :id, :event_id, :name
+  attributes :id, :event_id, :name, :admitted
   has_one :event
 end

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -1,4 +1,3 @@
 class ParticipantSerializer < ActiveModel::Serializer
   attributes :id, :event_id, :name, :admitted
-  has_one :event
 end

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
 class ParticipantSerializer < ActiveModel::Serializer
-  attributes :id, :event_id, :name, :admitted
+  attributes :id, :event_id, :name, :on_waiting_list
+
+  def on_waiting_list
+    object.waitlisted?
+  end
 end

--- a/spec/factories/participants.rb
+++ b/spec/factories/participants.rb
@@ -4,7 +4,6 @@ require 'faker'
 
 FactoryBot.define do
   factory :participant do
-    sequence(:id)
     sequence(:name) { |n| "参加者 #{n}" }
   end
 end

--- a/spec/factories/participants.rb
+++ b/spec/factories/participants.rb
@@ -4,6 +4,7 @@ require 'faker'
 
 FactoryBot.define do
   factory :participant do
+    sequence(:id)
     sequence(:name) { |n| "参加者 #{n}" }
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -20,4 +20,29 @@ describe Event, type: :model do
       }
     end
   end
+
+  describe 'method' do
+    describe '#admitted_participant?' do
+      let(:quota) { 3 }
+      let(:event) { build_stubbed(:event, quota: quota) }
+
+      subject { event.admitted_participant?(event.participants.last.id) }
+
+      context "with admitted participant's id" do
+        before do
+          event.participants.build(attributes_for_list(:participant, quota))
+        end
+
+        it { is_expected.to eq(true) }
+      end
+
+      context "with not admitted participant's id" do
+        before do
+          event.participants.build(attributes_for_list(:participant, quota + 1))
+        end
+
+        it { is_expected.to eq(false) }
+      end
+    end
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -22,25 +22,36 @@ describe Event, type: :model do
   end
 
   describe 'method' do
-    describe '#admitted_participant_ids' do
-      subject { event.admitted_participant_ids }
+    describe '#waitlisted_participant_ids' do
+      subject { event.waitlisted_participant_ids }
 
       context 'with valid quota' do
         let(:quota) { 3 }
-        let(:event) {
+        let(:event) do
           build_stubbed(:event, quota: quota, participants: participants)
-        }
-        let(:participants) {
-          [*1..(quota + 1)].map { |i| build(:participant, id: i) }
-        }
-        let(:admitted_participants) { [*1..quota] }
+        end
 
-        it { is_expected.to eq(admitted_participants) }
+        context 'with waitlisted participant' do
+          let(:participants) do
+            [*1..(quota + 1)].map { |i| build(:participant, id: i) }
+          end
+          let(:waitlisted_participants) { [quota + 1] }
 
-        it 'caches admitted_participant_ids as an instance variable' do
-          subject
-          expect(event.instance_variable_get('@admitted_participant_ids'))
-            .to eq(admitted_participants)
+          it { is_expected.to eq(waitlisted_participants) }
+
+          it 'caches waitlisted_participant_ids as an instance variable' do
+            subject
+            expect(event.instance_variable_get('@waitlisted_participant_ids'))
+              .to eq(waitlisted_participants)
+          end
+        end
+
+        context 'with no waitlisted participant' do
+          let(:participants) do
+            [*1..(quota - 1)].map { |i| build(:participant, id: i) }
+          end
+
+          it { is_expected.to eq([]) }
         end
       end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -22,26 +22,31 @@ describe Event, type: :model do
   end
 
   describe 'method' do
-    describe '#admitted_participant?' do
-      let(:quota) { 3 }
-      let(:event) { build_stubbed(:event, quota: quota) }
+    describe '#admitted_participant_ids' do
+      subject { event.admitted_participant_ids }
 
-      subject { event.admitted_participant?(event.participants.last.id) }
+      context 'with valid quota' do
+        let(:quota) { 3 }
+        let(:event) {
+          build_stubbed(:event, quota: quota, participants: participants)
+        }
+        let(:participants) {
+          [*1..(quota + 1)].map { |i| build(:participant, id: i) }
+        }
+        let(:admitted_participants) { [*1..quota] }
 
-      context "with admitted participant's id" do
-        before do
-          event.participants.build(attributes_for_list(:participant, quota))
+        it { is_expected.to eq(admitted_participants) }
+
+        it 'caches admitted_participant_ids as an instance variable' do
+          subject
+          expect(event.instance_variable_get('@admitted_participant_ids'))
+            .to eq(admitted_participants)
         end
-
-        it { is_expected.to eq(true) }
       end
 
-      context "with not admitted participant's id" do
-        before do
-          event.participants.build(attributes_for_list(:participant, quota + 1))
-        end
-
-        it { is_expected.to eq(false) }
+      context 'with invalid quota' do
+        let(:event) { build(:event, quota: nil) }
+        it { is_expected.to eq([]) }
       end
     end
   end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -9,16 +9,25 @@ RSpec.describe Participant, type: :model do
     it { is_expected.to validate_presence_of(:name) }
   end
 
-  describe 'validation' do
+  describe 'method' do
     describe '#admitted' do
-      let(:event) { build_stubbed(:event, quota: 1) }
-      let(:participant) { build_stubbed(:participant, event: event) }
+      let(:event) { build(:event, quota: 1) }
 
-      subject { event }
+      before do
+        allow(event).to receive(:admitted_participant_ids).and_return([1, 2, 3])
+      end
 
-      it 'calls event.admitted_patricipant? once.' do
-        is_expected.to receive(:admitted_participant?).once.with(participant.id)
-        participant.admitted
+      subject { participant.admitted }
+      context 'when admitted' do
+        let(:participant) { build(:participant, event: event, id: 3) }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when not admitted' do
+        let(:participant) { build(:participant, event: event, id: 4) }
+
+        it { is_expected.to eq(false) }
       end
     end
   end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Participant, type: :model do
@@ -10,22 +12,23 @@ RSpec.describe Participant, type: :model do
   end
 
   describe 'method' do
-    describe '#admitted' do
+    describe '#waitlisted?' do
       let(:event) { build(:event, quota: 1) }
 
       before do
-        allow(event).to receive(:admitted_participant_ids).and_return([1, 2, 3])
+        allow(event).to receive(:waitlisted_participant_ids).and_return([4, 5])
       end
 
-      subject { participant.admitted }
-      context 'when admitted' do
-        let(:participant) { build(:participant, event: event, id: 3) }
+      subject { participant.waitlisted? }
+
+      context 'when waitlisted' do
+        let(:participant) { build(:participant, event: event, id: 4) }
 
         it { is_expected.to eq(true) }
       end
 
-      context 'when not admitted' do
-        let(:participant) { build(:participant, event: event, id: 4) }
+      context 'when not waitlisted' do
+        let(:participant) { build(:participant, event: event, id: 3) }
 
         it { is_expected.to eq(false) }
       end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Participant, type: :model do
-
   describe 'association' do
     it { is_expected.to belong_to(:event) }
   end
@@ -10,4 +9,29 @@ RSpec.describe Participant, type: :model do
     it { is_expected.to validate_presence_of(:name) }
   end
 
+  describe 'method' do
+    describe '.admitted' do
+      let(:quota) { 3 }
+      let(:event) { create(:event, quota: quota) }
+      let(:participant) { create(:participant, event: event) }
+
+      subject { participant.admitted }
+
+      context 'when the participant is admitted' do
+        before do
+          create_list(:participant, quota - 1, event: event)
+        end
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'the participant has to wait for cancellation' do
+        before do
+          create_list(:participant, quota, event: event)
+        end
+
+        it { is_expected.to eq(false) }
+      end
+    end
+  end
 end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -9,28 +9,16 @@ RSpec.describe Participant, type: :model do
     it { is_expected.to validate_presence_of(:name) }
   end
 
-  describe 'method' do
-    describe '.admitted' do
-      let(:quota) { 3 }
-      let(:event) { create(:event, quota: quota) }
-      let(:participant) { create(:participant, event: event) }
+  describe 'validation' do
+    describe '#admitted' do
+      let(:event) { build_stubbed(:event, quota: 1) }
+      let(:participant) { build_stubbed(:participant, event: event) }
 
-      subject { participant.admitted }
+      subject { event }
 
-      context 'when the participant is admitted' do
-        before do
-          create_list(:participant, quota - 1, event: event)
-        end
-
-        it { is_expected.to eq(true) }
-      end
-
-      context 'the participant has to wait for cancellation' do
-        before do
-          create_list(:participant, quota, event: event)
-        end
-
-        it { is_expected.to eq(false) }
+      it 'calls event.admitted_patricipant? once.' do
+        is_expected.to receive(:admitted_participant?).once.with(participant.id)
+        participant.admitted
       end
     end
   end

--- a/spec/requests/participants_spec.rb
+++ b/spec/requests/participants_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'Participants API', type: :request do
+  let(:event) { build_stubbed(:event) }
+  let(:participant) { build_stubbed(:participant, event: event) }
+
+  describe 'POST /events/:event_id/participants' do
+    let(:event_id) { event.id }
+    let(:params) { { participant: attributes_for(:participant) } }
+
+    before do
+      allow(Participant).to receive(:new).and_return(participant)
+    end
+
+    context 'success' do
+      before do
+        allow(participant).to receive(:save).and_return(true)
+      end
+
+      it { is_expected.to eq 201 }
+
+    end
+
+    context 'failure' do
+      before do
+        allow(participant).to receive(:save).and_return(false)
+      end
+
+      it { is_expected.to eq 422 }
+    end
+  end
+
+  describe 'DELETE /events/:event_id/participants/:id' do
+    let(:event_id) { event.id }
+    let(:id) { participant.id }
+
+    before do
+      allow(Participant).to receive(:find).and_return(participant)
+    end
+
+    context 'success' do
+      before do
+        allow(participant).to receive(:destroy).and_return(true)
+      end
+
+      it { is_expected.to eq 200 }
+    end
+
+    context 'failure' do
+      before do
+        allow(participant).to receive(:destroy).and_return(false)
+      end
+
+      it { is_expected.to eq 422 }
+    end
+  end
+end

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -6,7 +6,9 @@ describe EventSerializer, type: :serializer do
   let(:event) { build_stubbed(:event) }
 
   describe 'data' do
-    before { event.participants.build(attributes_for(:participant)) }
+    before do
+      event.participants.build(attributes_for(:participant, event: event))
+    end
 
     subject { serialize(event) }
 
@@ -17,7 +19,8 @@ describe EventSerializer, type: :serializer do
         quota: event.quota,
         participants: [{
           event_id: event.participants[0].event_id,
-          name: event.participants[0].name
+          name: event.participants[0].name,
+          admitted: event.participants[0].admitted
         }]
       )
     end

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -20,7 +20,7 @@ describe EventSerializer, type: :serializer do
         participants: [{
           event_id: event.participants[0].event_id,
           name: event.participants[0].name,
-          admitted: event.participants[0].admitted
+          on_waiting_list: event.participants[0].waitlisted?
         }]
       )
     end

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -13,7 +13,7 @@ describe ParticipantSerializer, type: :serializer do
       is_expected.to include_json(
         id: participant.id,
         event_id: participant.event_id,
-        admitted: participant.admitted
+        on_waiting_list: participant.waitlisted?
       )
     end
   end

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ParticipantSerializer, type: :serializer do
+  let(:event) { build_stubbed(:event) }
+  let(:participant) { build_stubbed(:participant, event: event) }
+
+  describe 'data' do
+    subject { serialize(participant) }
+
+    it do
+      is_expected.to include_json(
+        id: participant.id,
+        event_id: participant.event_id,
+        admitted: participant.admitted
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Overview:概要
参加者モデルに以下を追加して、キャンセル待ち機能を実装する。
- Participant Model にイベントに参加可能かを判定するメソッド
- Participant Serializer に参加可能かを示す属性

また、Participant についての Request テストが作成されていなかったため、今回追加する。 

### Technical changes:技術的変更点
- Participant Model にイベントに参加可能かを判定するメソッド
メソッド名： `admitted` 
機能： 参加者の配列を先頭からイベントの定員数だけ取得し、自身が含まれるかを判定

- Participant Serializer に参加可能かを示す属性
属性名： `admitted`
データ内容： 上記のメソッドの結果の真偽値

### Impact point:変更に関する影響箇所
フロントエンドに渡される Participant の json レスポンスに `admitted` 属性が含まれる

### Change of UserInterface:UIの変更
UIの変更はなし

### Todos
- [x] Participant の Request テストの追加
- [x] `admitted` メソッドの実装およびテストの追加
- [x] `admitted` 属性およびテストの追加
