### PR TITLE
Add origin and credential settings to cors initializer

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,10 +7,11 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins '*'
+    origins 'tebukuro.shinosakarb.org', 'localhost:4000'
 
     resource '*',
       headers: :any,
+      credentials: true,
       expose: ['access-token', 'expiry', 'token-type', 'uid', 'client'],
       methods: [:get, :post, :delete, :patch]
   end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'tebukuro.shinosakarb.org', 'localhost:4000'
+    origins Rails.env.development? ?  'localhost:4000' : 'tebukuro.shinosakarb.org'
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
### Overview:概要
Rails側で、フロントエンド側への CORS を許可するための設定を追加する。
現在、動作確認時などではこれらの設定は手動で行う必要があるため、本PR で設定を追加したい。

### Technical changes:技術的変更点
Issue #218 で検討した内容を元に、以下の設定を追加する。開発環境については、ローカルマシンで動作を確認した。
- cookie を使用するため、`credentials: true` を resource 設定に追加
- `credentials: true` の設定に伴い、以下のドメインを origin として指定
  - 本番環境のドメイン： `tebukuro.shinosakarb.org`
  - 開発環境のドメイン： `localhost:4000`

### Impact point:変更に関する影響箇所
本番および開発環境において、フロントエンドとバックエンド間でクロスオリジンでの通信が可能となる。

### Change of UserInterface:UIの変更
UI の変更はなし