### PR TITLE
Get Participant's name from User

### DIFF
--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -27,7 +27,7 @@ class ParticipantsController < ApplicationController
 
   # Only allow a trusted parameter "white list" through.
   def participant_params
-    params.require(:participant).permit(:name, :event_id)
+    params.require(:participant).permit(:event_id)
   end
 
   def set_participant

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -4,7 +4,9 @@ class Participant < ApplicationRecord
   belongs_to :user
   belongs_to :event
 
-  validates :name, presence: true
+  def name
+    user.name
+  end
 
   def waitlisted?
     event.waitlisted_participant_ids.include?(id)

--- a/db/migrate/20180315081922_remove_name_from_participant.rb
+++ b/db/migrate/20180315081922_remove_name_from_participant.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromParticipant < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :participants, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171215005955) do
+ActiveRecord::Schema.define(version: 20180315081922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,7 +45,6 @@ ActiveRecord::Schema.define(version: 20171215005955) do
   end
 
   create_table "participants", force: :cascade do |t|
-    t.string "name", null: false
     t.bigint "event_id"
     t.bigint "user_id"
     t.datetime "created_at", null: false

--- a/spec/factories/participants.rb
+++ b/spec/factories/participants.rb
@@ -4,7 +4,6 @@ require 'faker'
 
 FactoryBot.define do
   factory :participant do
-    sequence(:name) { |n| "参加者 #{n}" }
     user nil
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,8 +1,6 @@
 FactoryBot.define do
   factory :user do
+    name { ForgeryJa(:name).full_name }
     email { Faker::Internet.email }
-    password "password"
-    password_confirmation "password"
-    confirmed_at Date.today
   end
 end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -5,15 +5,20 @@ require 'rails_helper'
 RSpec.describe Participant, type: :model do
   describe 'association' do
     it { is_expected.to belong_to(:event) }
-  end
-
-  describe 'validation' do
-    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to belong_to(:user) }
   end
 
   describe 'method' do
+    let(:user) { build(:user) }
+    let(:event) { build(:event, quota: 1) }
+
+    describe '#name' do
+      let(:participant) { build(:participant, event: event, user: user) }
+      subject { participant.name }
+      it { is_expected.to eq(user.name) }
+    end
+
     describe '#waitlisted?' do
-      let(:event) { build(:event, quota: 1) }
 
       before do
         allow(event).to receive(:waitlisted_participant_ids).and_return([4, 5])

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -3,11 +3,14 @@
 require 'rails_helper'
 
 describe EventSerializer, type: :serializer do
+  let(:user) { build_stubbed(:user) }
   let(:event) { build_stubbed(:event) }
 
   describe 'data' do
     before do
-      event.participants.build(attributes_for(:participant, event: event))
+      event.participants.build(
+        attributes_for(:participant, event: event, user: user)
+      )
     end
 
     subject { serialize(event) }
@@ -19,7 +22,7 @@ describe EventSerializer, type: :serializer do
         quota: event.quota,
         participants: [{
           event_id: event.participants[0].event_id,
-          name: event.participants[0].name,
+          name: event.participants[0].user.name,
           on_waiting_list: event.participants[0].waitlisted?
         }]
       )

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 describe ParticipantSerializer, type: :serializer do
+  let(:user) { build_stubbed(:user) }
   let(:event) { build_stubbed(:event) }
-  let(:participant) { build_stubbed(:participant, event: event) }
+  let(:participant) { build_stubbed(:participant, event: event, user: user) }
 
   describe 'data' do
     subject { serialize(participant) }
@@ -13,6 +14,7 @@ describe ParticipantSerializer, type: :serializer do
       is_expected.to include_json(
         id: participant.id,
         event_id: participant.event_id,
+        name: participant.user.name,
         on_waiting_list: participant.waitlisted?
       )
     end


### PR DESCRIPTION
### Overview:概要
現在、参加者の名前はイベントの参加登録時にフォームで入力している。ユーザー認証機能の実装に伴い、参加者モデルがが従属するユーザーの名前から取得するように変更する。

### Technical changes:技術的変更点
- Model および DBスキーマから `name` を削除
- Model で User から `name` を取得するメソッドを追加
- Controller の strong_parameters から `name` を除外
- Serializer では追加した `name` メソッドで参加者名を取得

### Impact point:変更に関する影響箇所
影響なし。
フロントエンドには従来通りイベント参加者の名前が `name` として渡される。

### Todos:
- [x] Model、DBから name を削除
- [x] Model で name を User から取得するメソッドを追加
- [x] Controller のstrong_parameters から `name` を除外
- [x] Serializer のテストで name をUser から取得するものに修正