### PR TITLE
Add check user registered feature to Event Model and Event Serializer

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,6 +15,10 @@ class Event < ApplicationRecord
     @waitlisted_participant_ids ||= get_waitlisted_participant_ids
   end
 
+  def user_registered?(user)
+    user ? participants.map(&:user_id).include?(user.id) : false
+  end
+
   private
 
   def get_waitlisted_participant_ids

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -1,7 +1,11 @@
 class EventSerializer < ActiveModel::Serializer
-  attributes :id, :name, :description, :quota
+  attributes :id, :name, :description, :quota, :registered
 
   has_many :participants
+
+  def registered
+    object.user_registered?(scope)
+  end
 
   # TODO: communitiesモデルが作成されたら、GETのURLをattributesに加えます。
 end

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -4,7 +4,7 @@ class EventSerializer < ActiveModel::Serializer
   has_many :participants
 
   def registered
-    object.user_registered?(scope)
+    object.user_registered?(current_user)
   end
 
   # TODO: communitiesモデルが作成されたら、GETのURLをattributesに加えます。

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -60,5 +60,33 @@ describe Event, type: :model do
         it { is_expected.to eq([]) }
       end
     end
+
+    describe '#user_registered?' do
+      let(:user) { build_stubbed(:user) }
+      let(:event) { build_stubbed(:event) }
+
+      context 'when user logged in' do
+        subject { event.user_registered?(user) }
+
+        context 'with registered user' do
+          before do
+            event.participants.build(
+              attributes_for(:participant, event: event, user: user)
+            )
+          end
+          it { is_expected.to eq(true) }
+        end
+
+        context 'with NOT registered user' do
+          it { is_expected.to eq(false) }
+        end
+      end
+
+      context 'when user NOT logged in' do
+        subject { event.user_registered?(nil) }
+
+        it { is_expected.to eq(false) }
+      end
+    end
   end
 end

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -8,6 +8,7 @@ describe EventSerializer, type: :serializer do
 
   describe 'data' do
     before do
+      allow_any_instance_of(EventSerializer).to receive(:scope).and_return(user)
       event.participants.build(
         attributes_for(:participant, event: event, user: user)
       )
@@ -20,6 +21,7 @@ describe EventSerializer, type: :serializer do
         name: event.name,
         description: event.description,
         quota: event.quota,
+        registered: event.user_registered?(user),
         participants: [{
           event_id: event.participants[0].event_id,
           name: event.participants[0].user.name,

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -8,13 +8,12 @@ describe EventSerializer, type: :serializer do
 
   describe 'data' do
     before do
-      allow_any_instance_of(EventSerializer).to receive(:scope).and_return(user)
       event.participants.build(
         attributes_for(:participant, event: event, user: user)
       )
     end
 
-    subject { serialize(event) }
+    subject { serialize(event, scope: user, scope_name: :current_user) }
 
     it do
       is_expected.to include_json(

--- a/spec/support/serializer_helper.rb
+++ b/spec/support/serializer_helper.rb
@@ -1,7 +1,7 @@
 module SerializerHelper
-  def serialize(resource, opts={})
-    serializer = described_class.new(resource)
-    ActiveModelSerializers::Adapter.create(serializer, opts).to_json
+  def serialize(resource, opts = {})
+    serializer = described_class.new(resource, opts)
+    ActiveModelSerializers::Adapter.create(serializer).to_json
   end
 end
 


### PR DESCRIPTION
### Overview:概要
イベント情報の取得時にユーザーがイベントに参加登録済みかどうかを示す属性をEvent Serializer に追加する。

### Technical changes:技術的変更点
- Event Serializer
  - ユーザーが参加登録済みかどうかを示す `registered` 属性を追加
  - `registered` 属性では、Event Model の `user_registered` メソッドから登録状態を取得
- Event Model
  - `user_registered` メソッドを追加
ユーザ情報を受け取り、参加登録済みかを判定、登録済みなら`true`、未登録またはログインしていない場合は `false` を返す
- 判定処理について
参加登録済みかを判定する処理は以下の３パターンを検討しました。
１．  `user ? participants.map(&:user_id).include?(user.id) : false`
２．  `user ? participants.pluck(:user_id).include?(user.id) : false`
３．  `Participant.exists?(event_id: self.id, user_id: user.id)`

処理時間はどれもあまり変わりませんでした（ログのActiveRecord の処理時間が大体１０ｍｓぐらい）。１ 番目の処理がSQLを発行しない（controller の include 指定で取得済みの participants から user_id を取得するため）ので少し嬉しいかな、ということで採用しました。 

### Impact point:変更に関する影響箇所
Event Serializer にユーザーが参加済みかの情報が追加される（純粋なREST構造ではない）

### Change of UserInterface:UIの変更
変更なし
