### PR TITLE
Add Registration controller and cancel registration endpoint

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -17,6 +17,10 @@ class RegistrationsController < ApplicationController
 
   def set_participant
     @participant =
-      policy_scope(Participant).where(event_id: params[:event_id]).first
+      ParticipantPolicy::Scope.new(current_user, Participant).resolve(scope_query)
+  end
+
+  def scope_query
+    { event_id: params[:event_id] }
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RegistrationsController < ApplicationController
   before_action :authenticate_user!, only: [:destroy]
   before_action :set_participant, only: [:destroy]
@@ -15,7 +17,6 @@ class RegistrationsController < ApplicationController
 
   def set_participant
     @participant =
-      Participant.find_by(event_id: params[:event_id], user_id: current_user.id)
-    authorize @participant
+      policy_scope(Participant).where(event_id: params[:event_id]).first
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,21 @@
+class RegistrationsController < ApplicationController
+  before_action :authenticate_user!, only: [:destroy]
+  before_action :set_participant, only: [:destroy]
+
+  # DELETE /events/:id/registrations
+  def destroy
+    if @participant.destroy
+      render json: @participant.event
+    else
+      render json: @participant.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_participant
+    @participant =
+      Participant.find_by(event_id: params[:event_id], user_id: current_user.id)
+    authorize @participant
+  end
+end

--- a/app/policies/participant_policy.rb
+++ b/app/policies/participant_policy.rb
@@ -1,5 +1,13 @@
+# frozen_string_literal: true
+
 class ParticipantPolicy < ApplicationPolicy
   def destroy?
     user.id == record.user_id
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.where(user_id: user.id)
+    end
   end
 end

--- a/app/policies/participant_policy.rb
+++ b/app/policies/participant_policy.rb
@@ -6,8 +6,8 @@ class ParticipantPolicy < ApplicationPolicy
   end
 
   class Scope < Scope
-    def resolve
-      scope.where(user_id: user.id)
+    def resolve(query = {})
+      scope.find_by(query.merge(user_id: user.id))
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
   resources :events do
     resources :participants, only: %i[create destroy]
+    delete 'registrations', to: 'registrations#destroy'
   end
 
   namespace :subscription do

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'Registrations API', type: :request do
+  let(:user) { build_stubbed(:user) }
+  let(:event) { build_stubbed(:event) }
+  let(:participant) { build_stubbed(:participant, user: user, event: event) }
+
+  describe 'DELETE /events/:id/registrations' do
+    let(:id) { event.id }
+
+    before do
+      allow(Participant).to receive(:find_by).and_return(participant)
+      sign_in_with(user)
+    end
+
+    context 'success' do
+      before do
+        allow(participant).to receive(:destroy).and_return(true)
+      end
+
+      it { is_expected.to eq 200 }
+    end
+
+    context 'failure' do
+      before do
+        allow(participant).to receive(:destroy).and_return(false)
+      end
+
+      it { is_expected.to eq 422 }
+    end
+  end
+end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -11,9 +11,7 @@ RSpec.describe 'Registrations API', type: :request do
     let(:id) { event.id }
 
     before do
-      allow(Participant)
-        .to receive_message_chain(:where, :where, :first)
-        .and_return(participant)
+      allow(Participant).to receive(:find_by).and_return(participant)
       sign_in_with(user)
     end
 

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'Registrations API', type: :request do
@@ -9,7 +11,9 @@ RSpec.describe 'Registrations API', type: :request do
     let(:id) { event.id }
 
     before do
-      allow(Participant).to receive(:find_by).and_return(participant)
+      allow(Participant)
+        .to receive_message_chain(:where, :where, :first)
+        .and_return(participant)
       sign_in_with(user)
     end
 


### PR DESCRIPTION
### Overview:概要
ユーザー認証機能の追加に伴い、以下を追加する。
- イベントの参加登録を取り扱うRegistration Controller 
- 参加登録をキャンセルするエンドポイント `DELETE /event/:id/registrations`

### Technical changes:技術的変更点
- Registration Controller ではリクエストを投げたユーザーのIDと対象のイベントIDを持つ参加者を削除
- 削除後に対象イベントのjsonデータをレスポンスとして送信

ルーティングの設定方法はちょっと力技な感じがあるかなーと思ってます。
もっと良い方法があればご教示ください。。

### Impact point:変更に関する影響箇所
フロントエンドからの参加登録のキャンセルは  `DELETE /event/:id/registrations` エンドポイントへアクセスする必要がある。
ローカル環境でフロントとの動作確認を行い、参加者を削除後のイベントのjsonデータが渡されることを確認している。 

### Change of UserInterface:UIの変更
なし