### PR TITLE
Upgrade to ruby 2.4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.3-alpine3.7
+FROM ruby:2.4.4-alpine3.7
 
 RUN apk update && apk upgrade && apk add --update --no-cache alpine-sdk tzdata postgresql-dev nodejs postgresql-client
 RUN mkdir /app

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 
 # Define Ruby version
-ruby "2.4.3"
+ruby "2.4.4"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails'
 # Use PostgreSQL as the database for Active Record


### PR DESCRIPTION
### Overview:概要
Upgrade ruby version from 2.4.3 to 2.4.4 !

### Technical changes:技術的変更点
- Using docker image ruby:2.4.4-alpine3.7 (was 2.4.3-alpine3.7)