### PR TITLE
Add validation and method for allowing registration only before event starts

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,6 +11,10 @@ class Event < ApplicationRecord
             { greater_than_or_equal_to: 1,
               less_than_or_equal_to: 1000 }
 
+  validates :event_starts_at, presence: true
+  validates :event_ends_at, presence: true
+  validate :start_after_end?, if: %i[event_starts_at? event_ends_at?]
+
   def waitlisted_participant_ids
     @waitlisted_participant_ids ||= get_waitlisted_participant_ids
   end
@@ -19,9 +23,19 @@ class Event < ApplicationRecord
     user ? participants.map(&:user_id).include?(user.id) : false
   end
 
+  def within_deadline?
+    Time.current < event_starts_at
+  end
+
   private
 
   def get_waitlisted_participant_ids
     quota ? participant_ids.sort.drop(quota) : []
+  end
+
+  def start_after_end?
+    if event_ends_at <= event_starts_at
+      errors.add(:event_starts_at, :exceeds_end_time)
+    end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,9 +11,12 @@ class Event < ApplicationRecord
             { greater_than_or_equal_to: 1,
               less_than_or_equal_to: 1000 }
 
-  validates :event_starts_at, presence: true
-  validates :event_ends_at, presence: true
-  validate :start_after_end?, if: %i[event_starts_at? event_ends_at?]
+  validates :event_starts_at,
+            presence: true,
+            datetime_less: { less_than_or_equal_to: :event_ends_at }
+  validates :event_ends_at,
+            presence: true,
+            datetime_less: { greater_than_or_equal_to: :event_starts_at }
 
   def waitlisted_participant_ids
     @waitlisted_participant_ids ||= get_waitlisted_participant_ids
@@ -31,11 +34,5 @@ class Event < ApplicationRecord
 
   def get_waitlisted_participant_ids
     quota ? participant_ids.sort.drop(quota) : []
-  end
-
-  def start_after_end?
-    if event_ends_at <= event_starts_at
-      errors.add(:event_starts_at, :exceeds_end_time)
-    end
   end
 end

--- a/config/locales/models/event/en.yml
+++ b/config/locales/models/event/en.yml
@@ -14,3 +14,10 @@ ja:
         event_starts_at: Start time of Event
         event_ends_at: End time of Event
         address: Address
+        quota: Quota
+ja:
+  activerecord:
+    errors:
+      messages:
+        exceeds_end_time: exceeds end time of the event
+

--- a/config/locales/models/event/ja.yml
+++ b/config/locales/models/event/ja.yml
@@ -14,3 +14,10 @@ ja:
         event_starts_at: イベント開始時間
         event_ends_at: イベント終了時間
         address: アドレス
+        quota: 定員
+ja:
+  activerecord:
+    errors:
+      messages:
+        exceeds_end_time: が終了時間を超えています。
+

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -19,6 +19,36 @@ describe Event, type: :model do
           .is_less_than_or_equal_to(1000)
       }
     end
+
+    describe '#event_starts_at' do
+      it { is_expected.to validate_presence_of(:event_starts_at) }
+    end
+
+    describe '#event_ends_at' do
+      it { is_expected.to validate_presence_of(:event_ends_at) }
+    end
+
+    describe '#start_after_end?' do
+      let(:event) do
+        build_stubbed(
+          :event,
+          event_starts_at: date,
+          event_ends_at: Time.zone.parse('2018-03-01T09:00:00Z')
+        )
+      end
+
+      subject { event.valid? }
+
+      context 'with starts before ends' do
+        let(:date) { Time.zone.parse('2018-03-01T08:59:00Z') }
+        it { is_expected.to be_truthy }
+      end
+
+      context 'with starts after ends' do
+        let(:date) { Time.zone.parse('2018-03-01T09:00:00Z') }
+        it { is_expected.to be_falsey }
+      end
+    end
   end
 
   describe 'method' do
@@ -86,6 +116,24 @@ describe Event, type: :model do
         subject { event.user_registered?(nil) }
 
         it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#within_deadline?' do
+      let(:start_date) { Time.zone.parse('2018-03-01T09:00:00Z') }
+      let(:event) { build_stubbed(:event, event_starts_at: start_date) }
+      subject { event.within_deadline? }
+
+      before { allow(Time).to receive(:current).and_return(current_date) }
+
+      context 'with date whithin the deadline' do
+        let(:current_date) { Time.zone.parse('2018-03-01T08:59:59Z') }
+        it { is_expected.to be_truthy }
+      end
+
+      context 'with date over the deadline' do
+        let(:current_date) { Time.zone.parse('2018-03-01T09:00:00Z') }
+        it { is_expected.to be_falsey }
       end
     end
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -22,32 +22,18 @@ describe Event, type: :model do
 
     describe '#event_starts_at' do
       it { is_expected.to validate_presence_of(:event_starts_at) }
+      it {
+        is_expected.to validate_datetime_less_of(:event_starts_at)
+          .is_less_than_or_equal_to(:event_ends_at)
+      }
     end
 
     describe '#event_ends_at' do
       it { is_expected.to validate_presence_of(:event_ends_at) }
-    end
-
-    describe '#start_after_end?' do
-      let(:event) do
-        build_stubbed(
-          :event,
-          event_starts_at: date,
-          event_ends_at: Time.zone.parse('2018-03-01T09:00:00Z')
-        )
-      end
-
-      subject { event.valid? }
-
-      context 'with starts before ends' do
-        let(:date) { Time.zone.parse('2018-03-01T08:59:00Z') }
-        it { is_expected.to be_truthy }
-      end
-
-      context 'with starts after ends' do
-        let(:date) { Time.zone.parse('2018-03-01T09:00:00Z') }
-        it { is_expected.to be_falsey }
-      end
+      it {
+        is_expected.to validate_datetime_less_of(:event_ends_at)
+          .is_greater_than_or_equal_to(:event_starts_at)
+      }
     end
   end
 

--- a/spec/support/matchers/validate_datetime_of_matcher.rb
+++ b/spec/support/matchers/validate_datetime_of_matcher.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :validate_datetime_less_of do |attribute|
+  match do |model|
+    @attribute = attribute
+    @model = model
+
+    return false unless @attribute && @target
+
+    @model[@attribute] = Time.zone.now
+
+    less_or_greater_valid? && equal_valid?
+  end
+
+  chain :is_less_than_or_equal_to do |target|
+    @target = target
+    @less = true
+    @equal = true
+  end
+
+  chain :is_greater_than_or_equal_to do |target|
+    @target = target
+    @less = false
+    @equal = true
+  end
+
+  def less_or_greater_valid?
+    @model[@target] =
+      @less ? Time.zone.tomorrow : Time.zone.yesterday
+
+    valid_attribute?
+  end
+
+  def equal_valid?
+    @model[@target] = @model[@attribute]
+
+    valid_attribute?
+  end
+
+  def valid_attribute?
+    @model.valid?
+    @model.errors[@attribute].blank?
+  end
+end


### PR DESCRIPTION
### Overview:概要
イベント日時が過ぎたら参加登録できないようにするため、Event Model で以下の変更を行う。
- 開始日時、終了日時のバリデーションの追加
- `before_starting?` メソッドを追加し、現在時刻がイベント開始前かを判定するメソッドを追加

### Technical changes:技術的変更点
- 開始日時、終了日時のバリデーション
  - 入力は必須
  - 開始日時は終了日時より前の時間であること
  - 形式はISO8601 を前提とするが、DateTimeクラスに変換できる形式であればOK
ただし、タイムゾーンはUTCを前提とする
  - 不正な形式や暦に無い日時（１３月など）は Eventモデルの new 時に `nil` となるので、入力必須バリデーションで除外（エラーメッセージが不自然ですが、通常起こりにくい入力値なので良いかなと思ってます）

- `before_starting?` メソッド
  - 現在時刻（`Time.current` で取得）がイベントの開始時刻より前かを真偽値で返す
  - イベント登録時にイベント開始前の登録であるかを、このメソッドを使って判定

### Impact point:変更に関する影響箇所
イベント登録時に開始・終了日時の入力が必須となる。

### Change of UserInterface:UIの変更
変更なし