### PR TITLE
Add Event registration endpoint

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,8 +1,20 @@
 # frozen_string_literal: true
 
 class RegistrationsController < ApplicationController
-  before_action :authenticate_user!, only: [:destroy]
-  before_action :set_participant, only: [:destroy]
+  before_action :authenticate_user!, only: %i[create destroy]
+  before_action :set_participant, only: %i[destroy]
+
+  # POST /events/:id/registrations
+  def create
+    @participant =
+      Participant.new(event_id: params[:id], user_id: current_user.id)
+
+    if @participant.save
+      render json: @participant.event
+    else
+      render json: @participant.errors, status: :unprocessable_entity
+    end
+  end
 
   # DELETE /events/:id/registrations
   def destroy
@@ -21,6 +33,6 @@ class RegistrationsController < ApplicationController
   end
 
   def scope_query
-    { event_id: params[:event_id] }
+    { event_id: params[:id] }
   end
 end

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -1,5 +1,6 @@
 class EventSerializer < ActiveModel::Serializer
-  attributes :id, :name, :description, :quota, :registered
+  attributes :id, :name, :description, :quota, :registered,
+    :event_starts_at, :event_ends_at
 
   has_many :participants
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,11 @@ Rails.application.routes.draw do
 
   resources :events do
     resources :participants, only: %i[create destroy]
-    delete 'registrations', to: 'registrations#destroy'
+    member do
+      resource 'registrations',
+               controller: :registrations,
+               only: %i[create destroy]
+    end
   end
 
   namespace :subscription do

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -7,6 +7,30 @@ RSpec.describe 'Registrations API', type: :request do
   let(:event) { build_stubbed(:event) }
   let(:participant) { build_stubbed(:participant, user: user, event: event) }
 
+  describe 'POST /events/:id/registrations' do
+    let(:id) { event.id }
+
+    before do
+      sign_in_with(user)
+    end
+
+    context 'success' do
+      before do
+        allow_any_instance_of(Participant).to receive(:save).and_return(true)
+      end
+
+      it { is_expected.to eq 200 }
+    end
+
+    context 'failure' do
+      before do
+        allow(participant).to receive(:save).and_return(false)
+      end
+
+      it { is_expected.to eq 422 }
+    end
+  end
+
   describe 'DELETE /events/:id/registrations' do
     let(:id) { event.id }
 

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -21,6 +21,8 @@ describe EventSerializer, type: :serializer do
         description: event.description,
         quota: event.quota,
         registered: event.user_registered?(user),
+        event_starts_at: event.event_starts_at,
+        event_ends_at: event.event_ends_at,
         participants: [{
           event_id: event.participants[0].event_id,
           name: event.participants[0].user.name,


### PR DESCRIPTION
### Overview:概要
イベント参加登録用のエンドポイント`POST /events/:id/registrations`を追加し、イベントの登録処理はこのエンドポイントで行うようにする。

### Technical changes:技術的変更点
- イベント参加登録用のエンドポイント`POST /events/:id/registrations`を追加
- 登録後はイベントおよびその参加者リストの json を返す
- イベントのjsonレスポンスに `event_starts_at`と、`event_ends_at` 属性を追加

### Impact point:変更に関する影響箇所
イベント参加登録のエンドポイントが、
`POST /events/:id/participants` から `POST /events/:id/registrations` に変更となる　

### Change of UserInterface:UIの変更
変更なし
