### PR TITLE
Permit event_starts_at and event_ends_at params in Event controller

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -39,7 +39,9 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:name, :description, :quota)
+    params
+      .require(:event)
+      .permit(:name, :description, :quota, :event_starts_at, :event_ends_at)
   end
 
   def set_event


### PR DESCRIPTION
### Overview:概要
イベントの開始／終了時刻のパラメータをEventsController で許可していなかったため、許可する設定を追加。

### Impact point:変更に関する影響箇所
イベントの開始／終了時刻のパラメータが許可され、他のパラメータと共にイベントの作成時にModelに渡される。