### PR TITLE
Add UserParticipationSerializer for registered and waitlisted data

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -17,7 +17,7 @@ class EventsController < ApplicationController
   end
 
   def show
-    render json: @event, include: 'participants'
+    render json: @event, include: %w[user_participation participants]
   end
 
   def update

--- a/app/models/user_participant.rb
+++ b/app/models/user_participant.rb
@@ -1,0 +1,20 @@
+class UserParticipant
+  def initialize(params)
+    @event = params[:event]
+    @user = params[:current_user]
+  end
+
+  def registered?
+    @event.user_registered?(@user)
+  end
+
+  def on_waiting_list?
+    user_participant.try(:waitlisted?) || false
+  end
+
+  private
+
+  def user_participant
+    @user_participant ||= Participant.find_by(event: @event, user: @user)
+  end
+end

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -1,13 +1,11 @@
 class EventSerializer < ActiveModel::Serializer
-  attributes :id, :name, :description, :quota,
-    :event_starts_at, :event_ends_at, :user_participation
+  attributes :id, :name, :description, :quota, :event_starts_at, :event_ends_at
 
+  has_one :user_participation
   has_many :participants
 
   def user_participation
-    user_participant =
-      UserParticipant.new(event: object, current_user: current_user)
-    UserParticipantSerializer.new(user_participant).attributes
+    UserParticipant.new(event: object, current_user: current_user)
   end
 
   # TODO: communitiesモデルが作成されたら、GETのURLをattributesに加えます。

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -1,11 +1,13 @@
 class EventSerializer < ActiveModel::Serializer
-  attributes :id, :name, :description, :quota, :registered,
-    :event_starts_at, :event_ends_at
+  attributes :id, :name, :description, :quota,
+    :event_starts_at, :event_ends_at, :user_participation
 
   has_many :participants
 
-  def registered
-    object.user_registered?(current_user)
+  def user_participation
+    user_participant =
+      UserParticipant.new(event: object, current_user: current_user)
+    UserParticipantSerializer.new(user_participant).attributes
   end
 
   # TODO: communitiesモデルが作成されたら、GETのURLをattributesに加えます。

--- a/app/serializers/user_participant_serializer.rb
+++ b/app/serializers/user_participant_serializer.rb
@@ -1,0 +1,11 @@
+class UserParticipantSerializer < ActiveModel::Serializer
+  attributes :registered, :on_waiting_list
+
+  def registered
+    object.registered?
+  end
+
+  def on_waiting_list
+    object.on_waiting_list?
+  end
+end

--- a/spec/models/user_participant_spec.rb
+++ b/spec/models/user_participant_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UserParticipant do
+  describe 'method' do
+    let(:user) { build_stubbed(:user) }
+
+    describe '#registered?' do
+      let(:event) { build_stubbed(:event, id: 1, participants: [participant]) }
+      let(:participant) { build_stubbed(:participant, event_id: 1, user: user) }
+
+      context 'with user signed in' do
+        let(:user_participant) do
+          UserParticipant.new(event: event, current_user: user)
+        end
+
+        context 'with user registered' do
+          before { allow(event).to receive(:user_registered?).and_return(true) }
+
+          it 'returns true' do
+            expect(user_participant.registered?).to be_truthy
+          end
+        end
+
+        context 'with user not registered' do
+          before do
+            allow(event).to receive(:user_registered?).and_return(false)
+          end
+
+          it 'returns false' do
+            expect(user_participant.registered?).to be_falsey
+          end
+        end
+      end
+
+      context 'with user not signed in' do
+        let(:user_participant) do
+          UserParticipant.new(event: event, current_user: nil)
+        end
+
+        it 'returns false' do
+          expect(user_participant.registered?).to be_falsey
+        end
+      end
+    end
+
+    describe '#on_waiting_list' do
+      let(:event) { build_stubbed(:event, id: 1, participants: [participant]) }
+      let(:participant) { build_stubbed(:participant, event_id: 1, user: user) }
+
+      context 'with user signed in' do
+        let(:user_participant) do
+          UserParticipant.new(event: event, current_user: user)
+        end
+
+        context 'with user registered' do
+          before do
+            allow(Participant).to receive(:find_by).and_return(participant)
+          end
+
+          context 'on waitlisted' do
+            before do
+              allow(participant).to receive(:waitlisted?).and_return(true)
+            end
+
+            it 'returns true' do
+              expect(user_participant.on_waiting_list?).to be_truthy
+            end
+          end
+
+          context 'not on waitlisted' do
+            before do
+              allow(participant).to receive(:waitlisted?).and_return(false)
+            end
+
+            it 'returns false' do
+              expect(user_participant.on_waiting_list?).to be_falsey
+            end
+          end
+        end
+
+        context 'with user not registered' do
+          before do
+            allow(Participant).to receive(:find_by).and_return(nil)
+          end
+
+          it 'returns false' do
+            expect(user_participant.on_waiting_list?).to be_falsey
+          end
+        end
+      end
+
+      context 'with user not signed in' do
+        let(:user_participant) do
+          UserParticipant.new(event: event, current_user: nil)
+        end
+
+        it 'returns false' do
+          expect(user_participant.on_waiting_list?).to be_falsey
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -11,6 +11,7 @@ describe EventSerializer, type: :serializer do
       event.participants.build(
         attributes_for(:participant, event: event, user: user)
       )
+      allow(Participant).to receive(:find_by).and_return(event.participants.first)
     end
 
     subject { serialize(event, scope: user, scope_name: :current_user) }
@@ -20,7 +21,10 @@ describe EventSerializer, type: :serializer do
         name: event.name,
         description: event.description,
         quota: event.quota,
-        registered: event.user_registered?(user),
+        user_participation: {
+          registered: event.user_registered?(user),
+          on_waiting_list: false
+        },
         event_starts_at: event.event_starts_at,
         event_ends_at: event.event_ends_at,
         participants: [{

--- a/spec/serializers/user_participant_serializer_spec.rb
+++ b/spec/serializers/user_participant_serializer_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UserParticipantSerializer, type: :serializer do
+  let(:user) { build_stubbed(:user) }
+  let(:event) { build_stubbed(:event, quota: 1) }
+  let(:participant) { attributes_for(:participant, event: event, user: user) }
+  let(:user_participant) { UserParticipant.new(event: event, current_user: user) }
+
+  describe 'data' do
+    subject { serialize(user_participant) }
+
+    context 'with admitted registration' do
+      before do
+        event.participants.build(participant)
+        allow(Participant)
+          .to receive(:find_by).and_return(event.participants.first)
+      end
+
+      it {
+        is_expected.to include_json(
+          registered: true,
+          on_waiting_list: false
+        )
+      }
+    end
+
+    context 'with waitlisted registration' do
+      before do
+        2.times { event.participants.build(participant) }
+        allow(Participant)
+          .to receive(:find_by).and_return(event.participants.second)
+      end
+
+      it {
+        is_expected.to include_json(
+          registered: true,
+          on_waiting_list: true
+        )
+      }
+    end
+  end
+end


### PR DESCRIPTION
### Overview:概要
イベント詳細のエンドポイントにアクセスしてきたユーザーが、そのイベントに登録済みか、またキャンセル待ちかのデータを返す、`UserParticipationSerializer` を追加する。

### Technical changes:技術的変更点
- EventSerializer
  - `user_participation` 属性を追加し、UserParticipationSerializerにイベント・ユーザー情報を渡して呼びだす。
- UserParticipationSerializer
  - Participant テーブルからユーザーの参加者情報を取得、以下のデータを返す
  - `registered` ： ユーザーが登録しているか
  - `on_waiting_list` ： ユーザーがキャンセル待ちをしているか

### Impact point:変更に関する影響箇所
ユーザーはイベント情報にアクセスした場合、そのイベントに参加登録したかに加えて、キャンセル待ちかどうかについて確認できるようになる。

### Change of UserInterface:UIの変更
なし