### PR TITLE
Upgrade sprockets gem for security patches

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,7 @@ GEM
     puma (3.10.0)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
-    rack (2.0.3)
+    rack (2.0.5)
     rack-cors (1.0.2)
     rack-protection (2.0.0)
       rack
@@ -282,7 +282,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
### Overview:概要
sprockets gem の脆弱性対策として、gem のバージョンをアップグレードする。
tebukuro では sprockets は使用していないが、念のために実施する。

### Technical changes:技術的変更点
- `bundle update sprockets` コマンドで sprockets gem のバージョンを `3.7.1` → `3.7.2` にアップグレード
- 今回の脆弱性に対してRails の設定変更も必要なケースがあるが、tebukuro では対応の必要なし

### Impact point:変更に関する影響箇所
基本的に影響はなし。ただし、gem としてはアプリケーションに含まれているので、アップグレードしておく。