### PR TITLE
Add within_deadline attribute to event serializer

### DIFF
--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -1,11 +1,16 @@
 class EventSerializer < ActiveModel::Serializer
-  attributes :id, :name, :description, :quota, :event_starts_at, :event_ends_at
+  attributes :id, :name, :description, :quota,
+             :event_starts_at, :event_ends_at, :within_deadline
 
   has_one :user_participation
   has_many :participants
 
   def user_participation
     UserParticipant.new(event: object, current_user: current_user)
+  end
+
+  def within_deadline
+    object.within_deadline?
   end
 
   # TODO: communitiesモデルが作成されたら、GETのURLをattributesに加えます。

--- a/spec/acceptance/events_spec.rb
+++ b/spec/acceptance/events_spec.rb
@@ -3,9 +3,9 @@
 require 'acceptance_helper'
 
 def document_event_params
-  with_options :scope => :event do
-    parameter :name, "Event name"
-    parameter :description, "Event description"
+  with_options scope: :event do
+    parameter :name, 'Event name'
+    parameter :description, 'Event description'
     parameter :event_starts_at, 'Event starts at'
     parameter :event_ends_at, 'Event ends at'
     parameter :address, 'Event address'
@@ -14,12 +14,12 @@ def document_event_params
 end
 
 resource 'Event' do
-  header "Accept", "application/json"
-  header "Content-Type", "application/json"
+  header 'Accept', 'application/json'
+  header 'Content-Type', 'application/json'
 
-  let(:events) { build_stubbed_list(:event, 2) }
-  let(:event) { build_stubbed(:event) }
-  
+  let(:events) { build_stubbed_list(:event, 2, :partial_event_detail_information) }
+  let(:event) { build_stubbed(:event, :partial_event_detail_information) }
+
   response_field :id, 'Event id'
   response_field :name, 'Event name'
   response_field :description, 'Event description'
@@ -28,7 +28,7 @@ resource 'Event' do
   response_field :event_starts_at, 'Event starts at'
   response_field :event_ends_at, 'Event ends at'
   response_field :participants, 'Participants Collection'
-  
+
   route '/events', 'Events Collection' do
     get 'Returns all events' do
       before do
@@ -42,7 +42,7 @@ resource 'Event' do
 
     post 'Create event' do
       document_event_params
-      let(:params) { {event: attributes_for(:event)} }
+      let(:params) { { event: attributes_for(:event) } }
       let(:raw_post) { params.to_json }
 
       before do
@@ -63,7 +63,7 @@ resource 'Event' do
         before do
           allow(event).to receive(:save).and_return(false)
         end
-  
+
         example_request 'Createing event is failure' do
           expect(response_status).to eq 422
         end
@@ -98,7 +98,7 @@ resource 'Event' do
 
     patch 'Update event' do
       document_event_params
-      let(:params) { {event: attributes_for(:event, name: 'hogehoge')} }
+      let(:params) { { event: attributes_for(:event, name: 'hogehoge') } }
       let(:raw_post) { params.to_json }
 
       before do

--- a/spec/acceptance/registrations_spec.rb
+++ b/spec/acceptance/registrations_spec.rb
@@ -3,11 +3,11 @@
 require 'acceptance_helper'
 
 resource 'Registrations', type: :request do
-  header "Accept", "application/json"
-  header "Content-Type", "application/json"
+  header 'Accept', 'application/json'
+  header 'Content-Type', 'application/json'
 
   let(:user) { build_stubbed(:user) }
-  let(:event) { build_stubbed(:event) }
+  let(:event) { build_stubbed(:event, :partial_event_detail_information) }
   let(:participant) { build_stubbed(:participant, user: user, event: event) }
 
   response_field :id, 'Event id'

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe EventSerializer, type: :serializer do
   let(:user) { build_stubbed(:user) }
-  let(:event) { build_stubbed(:event) }
+  let(:event) { build_stubbed(:event, :partial_event_detail_information) }
 
   describe 'data' do
     before do
@@ -21,17 +21,18 @@ describe EventSerializer, type: :serializer do
         name: event.name,
         description: event.description,
         quota: event.quota,
-        user_participation: {
-          registered: event.user_registered?(user),
-          on_waiting_list: false
-        },
-        event_starts_at: event.event_starts_at,
-        event_ends_at: event.event_ends_at,
+        event_starts_at: event.event_starts_at.iso8601(3),
+        event_ends_at: event.event_ends_at.iso8601(3),
+        within_deadline: event.within_deadline?,
         participants: [{
           event_id: event.participants[0].event_id,
           name: event.participants[0].user.name,
           on_waiting_list: event.participants[0].waitlisted?
-        }]
+        }],
+        user_participation: {
+          registered: event.user_registered?(user),
+          on_waiting_list: false
+        }
       )
     end
   end


### PR DESCRIPTION
### Overview:概要
イベントが締め切り前かどうかを示す、`within_deadline` プロパティをEvent Serializer に追加する。
クライアントではこのプロパティにより、イベントの締め切り前後で表示を切り替える。

### Technical changes:技術的変更点
- Event Serializer に`within_deadline` を追加
- SpecのEvent用のFactoryについて、イベントの開始／終了時刻のテストデータを設定する `partial_event_detail_information` オプションが無かったので追加。
- これまでの Serializer および Acceptance の Spec ではイベントの開始／終了時刻について確認できて居なかったので、`partial_event_detail_information` オプションを追記して確認した。

### Impact point:変更に関する影響箇所
なし

### Change of UserInterface:UIの変更
なし