### PR TITLE
Add CORS confing to allow any origin to GET and POST to /events/ endpoints

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -15,4 +15,13 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       expose: ['access-token', 'expiry', 'token-type', 'uid', 'client'],
       methods: [:get, :post, :delete, :patch]
   end
+
+  allow do
+    origins '*'
+
+    resource '/events/*',
+      headers: :any,
+      expose: ['access-token', 'expiry', 'token-type', 'uid', 'client'],
+      methods: [:get, :post]
+  end
 end


### PR DESCRIPTION
### Overview:概要
他サイトに埋め込んだ参加フォームからの、
- イベント情報の取得（ＧＥＴ）
- イベントへの参加登録（ＰＯＳＴ）
を許可するための CORS の設定を追加する。

### Technical changes:技術的変更点
全てのoriginからのアクセスを、以下のように制限を設けて許可：
- origin : 不特定の他サイトからのアクセスなので、全ての origin を許可
- resource : イベント情報の取得と参加登録を行うので、`/events` 以下のリソースへのアクセスのみ許可
- methods : 情報取得に必要な GETメソッドと、 参加登録に必要な POSTメソッドのみ許可

開発環境にて設定を変更しながら、`/events` 以外のエンドポイントへのアクセスや、DELETE などの許可しないメソッドでのアクセスに対して、CORS エラーを返すことを確認した。

### Impact point:変更に関する影響箇所
- フロントのドメイン `tebukuro.shinosakarb.org` からのCORS設定に変更はなし。
- 任意のサイトからのアクセスについては、上述のリソースのみ許可されるようになる。

### Change of UserInterface:UIの変更
変更無し
