### PR TITLE
Check if  user has already registered on event registration

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -5,10 +5,17 @@ class Participant < ApplicationRecord
   belongs_to :event
 
   validate :cannot_join
+  validate :registered
 
   def cannot_join
     unless event.within_deadline?
       errors.add(:event_id, :cannot_join)
+    end
+  end
+
+  def registered
+    if event.user_registered?(user)
+      errors.add(:event_id, :registered)
     end
   end
 

--- a/config/locales/models/participant/en.yml
+++ b/config/locales/models/participant/en.yml
@@ -13,3 +13,4 @@ en:
           attributes:
             event_id:
               cannot_join: Cannot join
+              registered: Already registered 

--- a/config/locales/models/participant/ja.yml
+++ b/config/locales/models/participant/ja.yml
@@ -13,3 +13,4 @@ ja:
           attributes:
             event_id:
               cannot_join: 参加できません
+              registered: 登録済みです

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -45,15 +45,23 @@ RSpec.describe Participant, type: :model do
     let(:event) { build(:event, quota: 1) }
 
     context 'event' do
+      let(:participant) { event.participants.new(user: user) }
+
       before do
         allow(event).to receive(:within_deadline?).and_return(false)
+        allow(event).to receive(:user_registered?).with(user).and_return(true)
       end
 
       example 'Can not join' do
-        participant = event.participants.new
         participant.valid?
         expect(participant).not_to be_valid
         expect(participant.errors.messages[:event_id]).to include('参加できません')
+      end
+
+      example 'User already registered' do
+        participant.valid?
+        expect(participant).not_to be_valid
+        expect(participant.errors.messages[:event_id]).to include('登録済みです')
       end
     end
   end


### PR DESCRIPTION
### Overview:概要
現状では、同一アカウントでイベントに多重登録できてしまう。
そこで、参加登録処理にバリデーションを追加して多重登録を防止する。

### Technical changes:技術的変更点
- Event model の`user_registered`メソッドを利用して参加登録済みかを判定。
- local にエラーメッセージを追加

### Impact point:変更に関する影響箇所
同一のアカウントによるイベントへの多重登録ができなくなる。

### Change of UserInterface:UIの変更
変更なし
