### PR TITLE
Fix registration response to include the registered user in participants list

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -22,10 +22,6 @@ class Event < ApplicationRecord
     @waitlisted_participant_ids ||= get_waitlisted_participant_ids
   end
 
-  def user_registered?(user)
-    user ? participants.map(&:user_id).include?(user.id) : false
-  end
-
   def within_deadline?
     Time.current < event_starts_at
   end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -14,7 +14,7 @@ class Participant < ApplicationRecord
   end
 
   def registered
-    if event.user_registered?(user)
+    if registered?(user)
       errors.add(:event_id, :registered)
     end
   end
@@ -25,5 +25,11 @@ class Participant < ApplicationRecord
 
   def waitlisted?
     event.waitlisted_participant_ids.include?(id)
+  end
+
+  private
+
+  def registered?(user)
+    UserParticipant.new(event: event, current_user: user).registered?
   end
 end

--- a/app/models/user_participant.rb
+++ b/app/models/user_participant.rb
@@ -5,7 +5,7 @@ class UserParticipant
   end
 
   def registered?
-    @event.user_registered?(@user)
+    user_participant.present?
   end
 
   def on_waiting_list?

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -77,34 +77,6 @@ describe Event, type: :model do
       end
     end
 
-    describe '#user_registered?' do
-      let(:user) { build_stubbed(:user) }
-      let(:event) { build_stubbed(:event) }
-
-      context 'when user logged in' do
-        subject { event.user_registered?(user) }
-
-        context 'with registered user' do
-          before do
-            event.participants.build(
-              attributes_for(:participant, event: event, user: user)
-            )
-          end
-          it { is_expected.to eq(true) }
-        end
-
-        context 'with NOT registered user' do
-          it { is_expected.to eq(false) }
-        end
-      end
-
-      context 'when user NOT logged in' do
-        subject { event.user_registered?(nil) }
-
-        it { is_expected.to eq(false) }
-      end
-    end
-
     describe '#within_deadline?' do
       let(:start_date) { Time.zone.parse('2018-03-01T09:00:00Z') }
       let(:event) { build_stubbed(:event, event_starts_at: start_date) }

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Participant, type: :model do
 
       before do
         allow(event).to receive(:within_deadline?).and_return(false)
-        allow(event).to receive(:user_registered?).with(user).and_return(true)
+        allow_any_instance_of(UserParticipant).to receive(:registered?).and_return(true)
       end
 
       example 'Can not join' do

--- a/spec/models/user_participant_spec.rb
+++ b/spec/models/user_participant_spec.rb
@@ -5,18 +5,20 @@ require 'rails_helper'
 describe UserParticipant do
   describe 'method' do
     let(:user) { build_stubbed(:user) }
+    let(:event) { build_stubbed(:event, id: 1, participants: [participant]) }
+    let(:participant) { build_stubbed(:participant, event_id: 1, user: user) }
+
 
     describe '#registered?' do
-      let(:event) { build_stubbed(:event, id: 1, participants: [participant]) }
-      let(:participant) { build_stubbed(:participant, event_id: 1, user: user) }
-
       context 'with user signed in' do
         let(:user_participant) do
           UserParticipant.new(event: event, current_user: user)
         end
 
         context 'with user registered' do
-          before { allow(event).to receive(:user_registered?).and_return(true) }
+          before do
+            allow(Participant).to receive(:find_by).and_return(participant)
+          end
 
           it 'returns true' do
             expect(user_participant.registered?).to be_truthy
@@ -25,7 +27,7 @@ describe UserParticipant do
 
         context 'with user not registered' do
           before do
-            allow(event).to receive(:user_registered?).and_return(false)
+            allow(Participant).to receive(:find_by).and_return(nil)
           end
 
           it 'returns false' do
@@ -46,9 +48,6 @@ describe UserParticipant do
     end
 
     describe '#on_waiting_list' do
-      let(:event) { build_stubbed(:event, id: 1, participants: [participant]) }
-      let(:participant) { build_stubbed(:participant, event_id: 1, user: user) }
-
       context 'with user signed in' do
         let(:user_participant) do
           UserParticipant.new(event: event, current_user: user)

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -30,7 +30,7 @@ describe EventSerializer, type: :serializer do
           on_waiting_list: event.participants[0].waitlisted?
         }],
         user_participation: {
-          registered: event.user_registered?(user),
+          registered: true,
           on_waiting_list: false
         }
       )


### PR DESCRIPTION
### Overview:概要
イベントに参加登録済みかをチェックするバリデーションの追加後(#297 )に、イベント詳細ページから登録後に参加登録したユーザーが反映されない。
登録そのものは完了しているが、レスポンスに申し込んだユーザーが参加者として含まれていないためである。
このPRにより、この事象を修正する。

### Technical changes:技術的変更点
- 原因
はっきりとした原因は不明だが、以下のように推測。
#297 により追加したバリデーションでは、event モデルのインスタンスで`event.participants` にユーザーが含まれるかを問い合わせている。このバリデーションで取得した `event.participants` が参加登録後も保持され、シリアライズされていると推測される。
そして、参加登録したユーザーが参加者に含まれないままのデータが、レスポンスとして出力されているため、参加登録後にユーザーが参加者として表示されないものと考えられる。

- 対策
イベントへの登録状態は、UserParticipant モデル経由で確認する。
UserParticipant では Participant のレコードの存在有無で登録済みかを判定するよう変更。そしてイベントの登録状態の確認処理は UserParticipant に集約する。

### Impact point:変更に関する影響箇所
参加登録後にユーザーが参加者一覧に含まれるようになる。

### Change of UserInterface:UIの変更
なし