### PR TITLE
参加登録後の画面にユーザーが参加者一覧に追加されないことへの対策

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -8,7 +8,7 @@ class RegistrationsController < ApplicationController
   # POST /events/:id/registrations
   def create
     if @participant.save
-      render json: @participant.event
+      render json: participated_event
     else
       render json: @participant.errors, status: :unprocessable_entity
     end
@@ -17,7 +17,7 @@ class RegistrationsController < ApplicationController
   # DELETE /events/:id/registrations
   def destroy
     if @participant.destroy
-      render json: @participant.event
+      render json: participated_event
     else
       render json: @participant.errors, status: :unprocessable_entity
     end
@@ -31,6 +31,10 @@ class RegistrationsController < ApplicationController
   def set_participant
     @participant =
       ParticipantPolicy::Scope.new(current_user, Participant).resolve(scope_query)
+  end
+
+  def participated_event
+    Event.find(params[:id])
   end
 
   def scope_query

--- a/spec/acceptance/registrations_spec.rb
+++ b/spec/acceptance/registrations_spec.rb
@@ -24,6 +24,7 @@ resource 'Registrations', type: :request do
 
       before do
         allow(Participant).to receive(:new).and_return(participant)
+        allow(Event).to receive(:find).and_return(event)
         sign_in_with(user)
       end
 
@@ -53,6 +54,7 @@ resource 'Registrations', type: :request do
 
       before do
         allow(Participant).to receive(:find_by).and_return(participant)
+        allow(Event).to receive(:find).and_return(event)
         sign_in_with(user)
       end
 


### PR DESCRIPTION
### Overview:概要
イベントに参加登録済みかをチェックするバリデーションの追加後(#297 )に、イベント詳細ページから登録後に参加登録したユーザーが反映されない。
登録そのものは完了しているが、レスポンスに申し込んだユーザーが参加者として含まれていないためである。
このPRにより、この事象を修正する。

### Technical changes:技術的変更点
- 原因
はっきりとした原因は不明だが、以下のように推測。
#297 により追加したバリデーションでは、event モデルのインスタンスで`event.participants` にユーザーが含まれるかを問い合わせている。このバリデーションで取得した `event.participants` が参加登録後も保持され、シリアライズされていると推測される。
そして、参加登録したユーザーが参加者に含まれないままのデータが、レスポンスとして出力されているため、参加登録後にユーザーが参加者として表示されないものと考えられる。

- 対策
イベントの参加登録後（Paticipant のインスタンスの save 後）にEvent のインスタンスを再取得する。
この再取得したインスタンスをシリアライズすることで、最新の状態をクライアントに返す。

### Impact point:変更に関する影響箇所
参加登録後にユーザーが参加者一覧に含まれるようになる。

### Change of UserInterface:UIの変更
なし