### PR TITLE
Fix wait executing database for production

### DIFF
--- a/kubernetes/tebukuro.yml
+++ b/kubernetes/tebukuro.yml
@@ -56,10 +56,10 @@ spec:
             httpGet:
               path: /health_check.json
               port: 3000
-          command: ["/app/script/wait.sh", "bundle", "exec", "rails", "s"]
+          command: ["bundle", "exec", "rails", "s"]
         - image: gcr.io/cloudsql-docker/gce-proxy:1.12
           name: cloudsql-proxy
-          command: ["/cloud_sql_proxy"
+          command: ["/cloud_sql_proxy",
                     "-instances=$INSTANCE_CONNECTION_NAME=tcp:5432",
                     "-credential_file=/secrets/cloudsql/credentials.json"]
           volumeMounts:


### PR DESCRIPTION
### Overview:概要
tebukuroのDockerイメージが更新されない不具合修正

以下の理由によりtebukuroのDockerイメージが正常に起動できない
- Cloud SQLへ接続するためのProxyコマンドが正しくない
- Database接続待機がProductionではデータベースを指定しないと動作しないが、そもそもCloud SQLで立ち上がっている前提なので待機処理をする必要はない

### Technical changes:技術的変更点
特になし

### Impact point:変更に関する影響箇所
特になし
