### PR TITLE
Modify execute job node setting

### DIFF
--- a/kubernetes/deploy-tasks-job.yml
+++ b/kubernetes/deploy-tasks-job.yml
@@ -9,8 +9,11 @@ spec:
       labels:
         name: deploy-tasks
     spec:
-      nodeSelector:
-        cloud.google.com/gke-nodepool: default-pool
+      tolerations:
+        - key: gke-preemptible
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       restartPolicy: Never
       containers:
         - name: deploy-tasks-runner


### PR DESCRIPTION
### Overview:概要
`db:migrate`を実行するJobのNodepool指定を変更する

migrateを実行するJobはプリエンプティブVMのnodepoolでも問題ないためその設定がされているnodepoolを優先的に指定する設定を追加し、Kubernetesのリソースを有効に活用する。

### Technical changes:技術的変更点
- Jobを実行するNodepool指定を変更（該当Nodepoolがない場合は別のNodepoolで実行されるので問題ない）

### Impact point:変更に関する影響箇所
特になし