### PR TITLE
Add check-in status column to Participant

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -4,8 +4,10 @@ class Participant < ApplicationRecord
   belongs_to :user
   belongs_to :event
 
-  validate :cannot_join
-  validate :registered
+  validate :cannot_join, on: :create
+  validate :registered, on: :create
+
+  enum status: %i[not_checked_in checked_in]
 
   def cannot_join
     unless event.within_deadline?
@@ -25,5 +27,9 @@ class Participant < ApplicationRecord
 
   def waitlisted?
     event.waitlisted_participant_ids.include?(id)
+  end
+
+  def toggle_status
+    checked_in? ? not_checked_in! : checked_in!
   end
 end

--- a/db/migrate/20181023150327_add_checked_in_column.rb
+++ b/db/migrate/20181023150327_add_checked_in_column.rb
@@ -1,0 +1,5 @@
+class AddCheckedInColumn < ActiveRecord::Migration[5.1]
+  def change
+    add_column :participants, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180315081922) do
+ActiveRecord::Schema.define(version: 20181023150327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 20180315081922) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["event_id"], name: "index_participants_on_event_id"
     t.index ["user_id"], name: "index_participants_on_user_id"
   end


### PR DESCRIPTION
### Overview:概要
イベント参加者のチェックイン機能を実装するため、Participant テーブルにstatusカラムを追加する。
追加した status カラムで参加者のチェックイン状態を記録する。

### Technical changes:技術的変更点
- Participant モデルでは、status を enum として定義する。
理由： ｀participant.check_in!｀ のように、チェックイン処理を簡単に実装したい

- status の切替メソッド `toggle_status` を実装

- バリデーションは参加登録時のみ必要で、チェックイン状態の変更には不要なので、`on: :create`オプションを追加

### Impact point:変更に関する影響箇所
エンドポイントの追加は行わないので、他の箇所への影響はない

### Change of UserInterface:UIの変更
なし