### PR TITLE
Add organizer_id column to Event model

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,7 @@
 class EventsController < ApplicationController
-
-  before_action :set_event, only: [:show, :update, :destroy]
-  before_action :build_event, only: [:create]
+  before_action :authenticate_user!, only: %i[create update destroy]
+  before_action :set_event, only: %i[show update destroy]
+  before_action :build_event, only: :create
 
   def index
     @events = Event.all
@@ -49,6 +49,6 @@ class EventsController < ApplicationController
   end
 
   def build_event
-    @event = Event.new(event_params)
+    @event = Event.new(event_params.merge(organizer: current_user))
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
+  belongs_to :organizer, class_name: 'User'
+
   has_many :participants
   has_many :tickets
 
   validates :name, presence: true
+  validates :organizer, presence: true
   validates :quota,
             presence: true,
             numericality:

--- a/db/migrate/20181026170908_add_organizer_id_column.rb
+++ b/db/migrate/20181026170908_add_organizer_id_column.rb
@@ -1,0 +1,5 @@
+class AddOrganizerIdColumn < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :events, :organizer, foreign_key: { to_table: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181023150327) do
+ActiveRecord::Schema.define(version: 20181026170908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,7 +32,9 @@ ActiveRecord::Schema.define(version: 20181023150327) do
     t.datetime "event_ends_at"
     t.string "address"
     t.integer "quota", null: false
+    t.bigint "organizer_id"
     t.index ["community_id"], name: "index_events_on_community_id"
+    t.index ["organizer_id"], name: "index_events_on_organizer_id"
   end
 
   create_table "owners", force: :cascade do |t|
@@ -105,6 +107,7 @@ ActiveRecord::Schema.define(version: 20181023150327) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "events", "users", column: "organizer_id"
   add_foreign_key "owners", "communities"
   add_foreign_key "owners", "users"
   add_foreign_key "participants", "events"

--- a/spec/acceptance/events_spec.rb
+++ b/spec/acceptance/events_spec.rb
@@ -13,10 +13,11 @@ def document_event_params
   end
 end
 
-resource 'Event' do
+resource 'Event', type: :request do
   header 'Accept', 'application/json'
   header 'Content-Type', 'application/json'
 
+  let(:user) { build_stubbed(:user) }
   let(:events) { build_stubbed_list(:event, 2, :partial_event_detail_information) }
   let(:event) { build_stubbed(:event, :partial_event_detail_information) }
 
@@ -47,6 +48,7 @@ resource 'Event' do
 
       before do
         allow(Event).to receive(:new).and_return(event)
+        sign_in_with(user)
       end
 
       context 'When saving is successful' do
@@ -103,6 +105,7 @@ resource 'Event' do
 
       before do
         allow(Event).to receive(:find).and_return(event)
+        sign_in_with(user)
       end
 
       context 'When the update successful' do
@@ -129,6 +132,7 @@ resource 'Event' do
     delete 'Delete event' do
       before do
         allow(Event).to receive(:find).and_return(event)
+        sign_in_with(user)
       end
 
       context 'When the delete successful' do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -12,6 +12,10 @@ describe Event, type: :model do
       it { is_expected.to validate_presence_of(:name) }
     end
 
+    describe '#organizer' do
+      it { is_expected.to validate_presence_of(:organizer) }
+    end
+
     describe '#quota' do
       it {
         is_expected.to validate_numericality_of(:quota)


### PR DESCRIPTION
### Overview:概要
チェックイン処理はイベントの運営者のみ行えることが望ましい。
そこで認証管理を行うために、Event モデルに `organizer_id` を追加してイベント作成者のユーザIDを保存する。

### Technical changes:技術的変更点
- 権限管理に必要なので、organizer は入力必須とする
- イベント作成時にController内で `current_user` を organizer として設定する
- イベントの作成、更新、削除時にはユーザー認証を行う（更新・削除機能はフロントエンドでは未実装なので権限管理は行わない）

### Impact point:変更に関する影響箇所
イベントの作成はログイン後のみ行えるようになる。

### Change of UserInterface:UIの変更
変更なし