### PR TITLE
Add endpoint and authorization for participant check-in 

### DIFF
--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -2,22 +2,22 @@
 
 class AttendancesController < ApplicationController
   before_action :authenticate_user!, only: %i[update]
-  before_action :set_participant, only: %i[update]
+  before_action :build_attendance, only: %i[update]
 
   # PATCH /participants/:id/attendances
   def update
-    authorize @participant, :toggle_status?
-    @participant.toggle_status
-    render json: participated_event
+    authorize @attendance, :update?
+    @attendance.update
+    render json: @attendance.event
   end
 
   private
 
-  def participated_event
-    Event.find(params[:id])
+  def build_attendance
+    @attendance = Attendance.new(participant: participant)
   end
 
-  def set_participant
-    @participant = Participant.find(params[:id])
+  def participant
+    Participant.find(params[:id])
   end
 end

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AttendancesController < ApplicationController
+  before_action :authenticate_user!, only: %i[update]
+  before_action :set_participant, only: %i[update]
+
+  # PATCH /participants/:id/attendances
+  def update
+    authorize @participant, :toggle_status?
+    @participant.toggle_status
+    render json: participated_event
+  end
+
+  private
+
+  def participated_event
+    Event.find(params[:id])
+  end
+
+  def set_participant
+    @participant = Participant.find(params[:id])
+  end
+end

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -1,0 +1,15 @@
+class Attendance
+  include ActiveModel::Model
+
+  def initialize(params = {})
+    @participant = params[:participant]
+  end
+
+  def update
+    @participant.toggle_status
+  end
+
+  def event
+    @participant.event
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,8 @@ class User < ActiveRecord::Base
   def owner?(community)
     community.owners.exists?(user: self)
   end
+
+  def organizer?(event)
+    event.organizer_id == id
+  end
 end

--- a/app/policies/attendance_policy.rb
+++ b/app/policies/attendance_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AttendancePolicy < ApplicationPolicy
+  def update?
+    user.organizer?(record.event)
+  end
+end

--- a/app/policies/participant_policy.rb
+++ b/app/policies/participant_policy.rb
@@ -5,6 +5,10 @@ class ParticipantPolicy < ApplicationPolicy
     user.id == record.user_id
   end
 
+  def toggle_status?
+    user.organizer?(record.event)
+  end
+
   class Scope < Scope
     def resolve(query = {})
       scope.find_by(query.merge(user_id: user.id))

--- a/app/policies/participant_policy.rb
+++ b/app/policies/participant_policy.rb
@@ -5,10 +5,6 @@ class ParticipantPolicy < ApplicationPolicy
     user.id == record.user_id
   end
 
-  def toggle_status?
-    user.organizer?(record.event)
-  end
-
   class Scope < Scope
     def resolve(query = {})
       scope.find_by(query.merge(user_id: user.id))

--- a/app/serializers/participant_serializer.rb
+++ b/app/serializers/participant_serializer.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class ParticipantSerializer < ActiveModel::Serializer
-  attributes :id, :event_id, :name, :on_waiting_list
+  attributes :id, :event_id, :name, :on_waiting_list, :checked_in
 
   def on_waiting_list
     object.waitlisted?
+  end
+
+  def checked_in
+    object.checked_in?
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,13 +3,6 @@
 Rails.application.routes.draw do
   health_check_routes
   mount_devise_token_auth_for 'User', at: 'auth'
-  resources :communities, shallow: true, defaults: { format: 'json' } do
-    resources :events do
-      resources :tickets do
-        resources :subscriptions, only: :create
-      end
-    end
-  end
 
   resources :events do
     member do
@@ -19,7 +12,11 @@ Rails.application.routes.draw do
     end
   end
 
-  namespace :subscription do
-    resources :tickets, only: :destroy
+  resources :participants, only: [] do
+    member do
+      resource 'attendances',
+               controller: :attendances,
+               only: %i[update]
+    end
   end
 end

--- a/spec/acceptance/attendances_spec.rb
+++ b/spec/acceptance/attendances_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'acceptance_helper'
+
+resource 'Attendances', type: :request do
+  header 'Accept', 'application/json'
+  header 'Content-Type', 'application/json'
+
+  let(:user) { build_stubbed(:user) }
+  let(:event) { build_stubbed(:event, :partial_event_detail_information) }
+  let(:participant) { build_stubbed(:participant, user: user, event: event) }
+
+  patch '/participants/:id/attendances' do
+    let(:id) { participant.id }
+
+    before do
+      allow(Participant).to receive(:find).and_return(participant)
+      allow(Event).to receive(:find).and_return(event)
+      allow(participant).to receive(:toggle_status)
+      sign_in_with(user)
+    end
+
+    context 'When authorization to update is successful' do
+      before { allow(user).to receive(:organizer?).and_return(true) }
+
+      example_request 'Update check-in status' do
+        expect(response_status).to eq(200)
+      end
+    end
+
+    context 'When authorization to update is failure' do
+      before { allow(user).to receive(:organizer?).and_return(false) }
+
+      example_request 'Update check-in status' do
+        expect(response_status).to eq(403)
+      end
+    end
+  end
+end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Participant, type: :model do
       end
     end
 
-    describe '#toggle_status' do
+    describe '#toggle_status!' do
       # Validations are executed for unpersisted models,
       # so mocking methods to pass these unexpected validation.
       before do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe User do
+  describe 'method' do
+    let(:user) { build(:user, id: 1) }
+
+    describe '#organizer?' do
+      context 'organizer of event' do
+        let(:event) { build_stubbed(:event, organizer_id: user.id) }
+
+        it 'returns false' do
+          expect(user.organizer?(event)).to be_truthy
+        end
+      end
+
+      context 'not organizer of event' do
+        let(:event) { build_stubbed(:event, organizer_id: 2) }
+
+        it 'returns false' do
+          expect(user.organizer?(event)).to be_falsey
+        end
+      end
+    end
+  end
+end

--- a/spec/policies/attendance_policy_spec.rb
+++ b/spec/policies/attendance_policy_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AttendancePolicy do
+  let(:user) { build_stubbed(:user) }
+
+  subject { described_class }
+
+  permissions :update? do
+    context 'user is the organizer of event' do
+      it 'grants access if user is the organizer of event.' do
+        event = build_stubbed(:event, organizer: user)
+        participant = build_stubbed(:participant, event: event, user: user)
+        expect(subject).to permit(user, participant)
+      end
+    end
+
+    context 'user is not the organizer of event' do
+      it 'denies access.' do
+        event = build_stubbed(:event)
+        participant = build_stubbed(:participant, event: event, user: user)
+        expect(subject).not_to permit(user, participant)
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,11 +2,11 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
 require 'shoulda/matchers'
-require "pundit/rspec"
+require 'pundit/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/serializers/participant_serializer_spec.rb
+++ b/spec/serializers/participant_serializer_spec.rb
@@ -15,7 +15,8 @@ describe ParticipantSerializer, type: :serializer do
         id: participant.id,
         event_id: participant.event_id,
         name: participant.user.name,
-        on_waiting_list: participant.waitlisted?
+        on_waiting_list: participant.waitlisted?,
+        checked_in: false
       )
     end
   end


### PR DESCRIPTION
### Overview:概要
参加者のチェックイン機能に対するエンドポイントと、そのアクセス権限の管理を行う。
参加者のチェックイン処理はイベント作成者のみ行えるようにする。

### Technical changes:技術的変更点
- エンドポイント `PUT/PATCH /participants/:id/attendances` を追加
  - 既存データの変更なので、PATCH メソッドでのアクセスを想定
  - エンドポイント名は `check-in` ではなく、ハイフンが入らず複数形でも自然な `attendance` とする
- `toggle_status` メソッドの実行権限は `current_user` がイベント作成者の時のみ認める

### Impact point:変更に関する影響箇所
新規のルーティングとコントローラの追加なので、既存の処理に影響はなし

### Change of UserInterface:UIの変更
変更なし
